### PR TITLE
Add basic authorization for brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,23 @@ The settings exposed here are targeted to more advanced users that want to custo
 |QueuedMaxMessagesKbytes|queued.max.messages.kbytes|Trigger
 |MaxPartitionFetchBytes|max.partition.fetch.bytes|Trigger
 |FetchMaxBytes|fetch.max.bytes|Trigger
+|AutoCommitIntervalMs|auto.commit.interval.ms|Trigger
 
 If you are missing an configuration setting please create an issue and describe why you need it.
+
+## Connecting to a secure Kafka broker
+
+Both, trigger and output, can connect to a secure Kafka broker. The following attribute properties are available to establish a secure connection:
+
+|Setting|librdkafka property|Description|
+|-|-|-|
+|AuthenticationMode|sasl.mechanism|SASL mechanism to use for authentication|
+|Username|sasl.username|SASL username for use with the PLAIN and SASL-SCRAM|
+|Password|sasl.password|SASL password for use with the PLAIN and SASL-SCRAM|
+|Protocol|security.protocol|Security protocol used to communicate with brokers|
+|SslKeyLocation|ssl.key.location|Path to client's private key (PEM) used for authentication|
+
+Username and password should reference a Azure function configuration variable and not be hardcoded.
 
 ## Quickstart
 

--- a/samples/dotnet/KafkaFunctionSample/AvroSpecificTriggers.cs
+++ b/samples/dotnet/KafkaFunctionSample/AvroSpecificTriggers.cs
@@ -41,7 +41,6 @@ namespace KafkaFunctionSample
         /// <summary>
         /// This function shows how to implement a custom deserialiser in the function method
         /// </summary>
-        /// <returns>The as bytes.</returns>
         /// <param name="kafkaEvents">Kafka events.</param>
         /// <param name="logger">Logger.</param>
         [FunctionName(nameof(UserAsBytes))]
@@ -59,8 +58,7 @@ namespace KafkaFunctionSample
         /// <summary>
         /// This function shows how to implement a custom deserialiser in the function method
         /// </summary>
-        /// <returns>The as bytes.</returns>
-        /// <param name="kafkaEvents">Kafka events.</param>
+        /// <param name="kafkaEvent">Kafka events.</param>
         /// <param name="logger">Logger.</param>
         [FunctionName(nameof(UserAsByte))]
         public static async Task UserAsByte(

--- a/samples/dotnet/KafkaFunctionSample/ProduceStringTopic.cs
+++ b/samples/dotnet/KafkaFunctionSample/ProduceStringTopic.cs
@@ -6,7 +6,6 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Microsoft.Azure.WebJobs.Extensions.Kafka;
 
 namespace KafkaFunctionSample

--- a/samples/dotnet/KafkaFunctionSample/RawTypeTriggers.cs
+++ b/samples/dotnet/KafkaFunctionSample/RawTypeTriggers.cs
@@ -1,16 +1,6 @@
-using System;
-using System.IO;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Microsoft.Azure.WebJobs.Extensions.Kafka;
-using Avro.Generic;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace KafkaFunctionSample
 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/BrokerAuthenticationMode.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/BrokerAuthenticationMode.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Confluent.Kafka;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    /// <summary>
+    /// Defines the broker authentication modes
+    /// </summary>
+    public enum BrokerAuthenticationMode
+    {
+        // Force that 0 starts like the one from librdkafka
+        NotSet = -1,
+        Gssapi,
+        Plain,
+        ScramSha256,
+        ScramSha512
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/BrokerProtocol.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/BrokerProtocol.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    /// <summary>
+    /// Defines the broker protocols
+    /// </summary>
+    public enum BrokerProtocol
+    {
+        // Force that 0 starts like the one from librdkafka
+        NotSet = -1,
+        Plaintext,
+        Ssl,
+        SaslPlaintext,
+        SaslSsl
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaExtensionConfigProvider.cs
@@ -90,11 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         {
             try
             {
-                if (kafkaEventData.Value is GenericRecord genericRecord)
-                {
-                    return GenericRecord2String(genericRecord);
-                }
-                else if (kafkaEventData.Value is byte[] binaryContent)
+                if (kafkaEventData.Value is byte[] binaryContent)
                 {
                     if (binaryContent != null)
                     {
@@ -104,6 +100,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                     {
                         return string.Empty;
                     }
+                }
+                else if (kafkaEventData.Value is GenericRecord genericRecord)
+                {
+                    return GenericRecord2String(genericRecord);
                 }
                 else
                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -127,6 +127,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             }
         }
 
+        /// <summary>
+        /// Gets or sets the auto commit interval ms.
+        /// Default = 200ms
+        /// 
+        /// Librdkafka: auto.commit.interval.ms (default 5000)
+        /// </summary>
+        /// <value>The auto commit interval ms.</value>
+        public int AutoCommitIntervalMs { get; set; } = 200;
+
         int subscriberIntervalInSeconds = 1;
         /// <summary>
         /// Defines the minimum frequency in which messages will be executed by function. Only if the message volume is less than <see cref="MaxBatchSize"/> / <see cref="SubscriberIntervalInSeconds"/>
@@ -146,7 +155,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 this.subscriberIntervalInSeconds = value;
             }
         }
-
 
         int executorChannelCapacity = 10;
         /// <summary>
@@ -194,7 +202,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             var serializerSettings = new JsonSerializerSettings()
             {
                 DefaultValueHandling = DefaultValueHandling.Ignore,
-                Formatting = Formatting.Indented
+                Formatting = Formatting.Indented,
             };
 
             return JsonConvert.SerializeObject(this, serializerSettings);

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Extensions/ConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    internal static class ConfigurationExtensions
+    {
+        internal static string ResolveSecureSetting(this IConfiguration config, INameResolver nameResolver, string currentValue)
+        {
+            if (string.IsNullOrWhiteSpace(currentValue))
+            {
+                return currentValue;
+            }
+
+            var resolved = nameResolver.ResolveWholeString(currentValue);
+            var resolvedFromConfig = config.GetConnectionStringOrSetting(resolved);
+            return !string.IsNullOrEmpty(resolvedFromConfig) ? resolvedFromConfig : resolved;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListenerFactory.cs
@@ -19,10 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             ITriggeredFunctionExecutor executor,
             bool singleDispatch,
             KafkaOptions options,
-            string brokerList,
-            string topic,
-            string consumerGroup,
-            string eventHubConnectionString,
+            KafkaListenerConfiguration consumerKafkaConfiguration,
             ILogger logger)
         {
             var valueType = SerializationHelper.GetValueType(attribute.ValueType, attribute.AvroSchema, parameterType, out var avroSchema);
@@ -35,10 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                     executor,
                     singleDispatch,
                     options,
-                    brokerList,
-                    topic,
-                    consumerGroup,
-                    eventHubConnectionString,
+                    consumerKafkaConfiguration,
                     valueDeserializer,
                     logger
                 });

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Avro.Specific;
+using Confluent.Kafka;
 using Microsoft.Azure.WebJobs.Description;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka
@@ -116,5 +117,45 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// </summary>
         /// <remarks>Retrying may cause reordering unless <c>EnableIdempotence</c> is set to <c>true</c>.</remarks>
         public int? MaxRetries { get; set; }
+
+        /// <summary>
+        /// SASL mechanism to use for authentication. 
+        /// Allowed values: Gssapi, Plain, ScramSha256, ScramSha512
+        /// Default: Plain
+        /// 
+        /// sasl.mechanism in librdkafka
+        /// </summary>
+        public BrokerAuthenticationMode AuthenticationMode { get; set; } = BrokerAuthenticationMode.NotSet;
+
+        /// <summary>
+        /// SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
+        /// Default: ""
+        /// 
+        /// 'sasl.username' in librdkafka
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        /// SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
+        /// Default: ""
+        /// 
+        /// sasl.password in librdkafka
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the security protocol used to communicate with brokers
+        /// Default is plain text
+        /// 
+        /// security.protocol in librdkafka
+        /// </summary>
+        public BrokerProtocol Protocol { get; set; } = BrokerProtocol.NotSet;
+
+        /// <summary>
+        /// Path to client's private key (PEM) used for authentication.
+        /// Default: ""
+        /// ssl.key.location in librdkafka
+        /// </summary>
+        public string SslKeyLocation { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaListenerConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaListenerConfiguration.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Confluent.Kafka;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    /// <summary>
+    /// Kafka listener configuration.
+    /// </summary>
+    public class KafkaListenerConfiguration
+    {
+        /// <summary>
+        /// SASL mechanism to use for authentication. 
+        /// Allowed values: Gssapi, Plain, ScramSha256, ScramSha512
+        /// Default: Plain
+        /// 
+        /// sasl.mechanism in librdkafka
+        /// </summary>
+        public SaslMechanism? SaslMechanism { get; set; }
+
+        /// <summary>
+        /// SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
+        /// Default: ""
+        /// 
+        /// 'sasl.username' in librdkafka
+        /// </summary>
+        public string SaslUsername { get; set; }
+
+
+        /// <summary>
+        /// SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
+        /// Default: ""
+        /// 
+        /// sasl.password in librdkafka
+        /// </summary>
+        public string SaslPassword { get; set; }
+
+
+        /// <summary>
+        /// Gets or sets the security protocol used to communicate with brokers
+        /// Default is plain text
+        /// 
+        /// security.protocol in librdkafka
+        /// </summary>
+        public SecurityProtocol? SecurityProtocol { get; set; }
+
+        /// <summary>
+        /// Path to client's private key (PEM) used for authentication.
+        /// Default: ""
+        /// ssl.key.location in librdkafka
+        /// </summary>
+        public string SslKeyLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the broker list.
+        /// </summary>
+        /// <value>The broker list.</value>
+        public string BrokerList { get; set; }
+
+        /// <summary>
+        /// Gets or sets the event hub connection string.
+        /// </summary>
+        /// <value>The event hub connection string.</value>
+        public string EventHubConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the topic.
+        /// </summary>
+        /// <value>The topic.</value>
+        public string Topic { get; set; }
+
+        /// <summary>
+        /// Gets or sets the consumer group.
+        /// </summary>
+        /// <value>The consumer group.</value>
+        public string ConsumerGroup { get; set; }
+
+        internal void ApplyToConfig(ClientConfig conf)
+        {
+            if (this.SaslMechanism.HasValue)
+            {
+                conf.SaslMechanism = this.SaslMechanism.Value;
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.SaslUsername))
+            {
+                conf.SaslUsername = this.SaslUsername;
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.SaslPassword))
+            {
+                conf.SaslPassword = this.SaslPassword;
+            }
+
+            if (this.SecurityProtocol.HasValue)
+            {
+                conf.SecurityProtocol = this.SecurityProtocol.Value;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Avro.Specific;
+using Confluent.Kafka;
 using Microsoft.Azure.WebJobs.Description;
 using System;
 
@@ -10,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
     /// <summary>
     /// Trigger attribute to start execution of function when Kafka messages are received
     /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter)]
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
     [Binding]
     public class KafkaTriggerAttribute : Attribute
     {
@@ -72,6 +73,47 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// Should be used only if a generic record should be generated
         /// </summary>
         public string AvroSchema { get; set; }
+
+        /// <summary>
+        /// SASL mechanism to use for authentication. 
+        /// Allowed values: Gssapi, Plain, ScramSha256, ScramSha512
+        /// Default: Plain
+        /// 
+        /// sasl.mechanism in librdkafka
+        /// </summary>
+        public BrokerAuthenticationMode AuthenticationMode { get; set; } = BrokerAuthenticationMode.NotSet;
+
+        /// <summary>
+        /// SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms
+        /// Default: ""
+        /// 
+        /// 'sasl.username' in librdkafka
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        /// SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism
+        /// Default: ""
+        /// 
+        /// sasl.password in librdkafka
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the security protocol used to communicate with brokers
+        /// Default is plain text
+        /// 
+        /// security.protocol in librdkafka
+        /// </summary>
+        public BrokerProtocol Protocol { get; set; } = BrokerProtocol.NotSet;
+
+        /// <summary>
+        /// Path to client's private key (PEM) used for authentication.
+        /// Default: ""
+        /// ssl.key.location in librdkafka
+        /// </summary>
+        public string SslKeyLocation { get; set; }
+
 
         bool IsValidValueType(Type value)
         {

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Helpers/KafkaListenerForTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Helpers/KafkaListenerForTest.cs
@@ -16,22 +16,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         private IConsumer<TKey, TValue> consumer;
         private ConsumerBuilder<TKey, TValue> consumerBuilder;
 
+        public ConsumerConfig ConsumerConfig { get; private set; }
+
         public KafkaListenerForTest(ITriggeredFunctionExecutor executor,
             bool singleDispatch,
             KafkaOptions options,
-            string brokerList,
-            string topic,
-            string consumerGroup,
-            string eventHubConnectionString,
+            KafkaListenerConfiguration kafkaListenerConfiguration,
             object valueDeserializer,
             ILogger logger)
             : base(executor,
                 singleDispatch,
                 options,
-                brokerList,
-                topic,
-                consumerGroup,
-                eventHubConnectionString,
+                kafkaListenerConfiguration,
                 valueDeserializer,
                 logger)
         {
@@ -44,6 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
         protected override ConsumerBuilder<TKey, TValue> CreateConsumerBuilder(ConsumerConfig config)
         {
+            this.ConsumerConfig = config;
             return this.consumerBuilder ?? new TestConsumerBuilder<TKey, TValue>(config, this.consumer);
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerFactoryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerFactoryTest.cs
@@ -21,6 +21,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             };
 
             var executor = new Mock<ITriggeredFunctionExecutor>();
+            var listenerConfig = new KafkaListenerConfiguration()
+            {
+                BrokerList = attribute.BrokerList,
+                Topic = attribute.Topic,
+                ConsumerGroup = "group1",
+            };
 
             var listener = KafkaListenerFactory.CreateFor(
                 attribute,
@@ -28,10 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 executor.Object,
                 true,
                 new KafkaOptions(),
-                "brokers:9092",
-                "myTopic",
-                "group1",
-                null,
+                listenerConfig,
                 NullLogger.Instance);
 
             Assert.NotNull(listener);
@@ -49,6 +52,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             };
 
             var executor = new Mock<ITriggeredFunctionExecutor>();
+            var listenerConfig = new KafkaListenerConfiguration()
+            {
+                BrokerList = attribute.BrokerList,
+                Topic = attribute.Topic,
+                ConsumerGroup = "group1",
+            };
 
             var listener = KafkaListenerFactory.CreateFor(
                 attribute,
@@ -56,10 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 executor.Object,
                 true,
                 new KafkaOptions(),
-                "brokers:9092",
-                "myTopic",
-                "group1",
-                null,
+                listenerConfig,
                 NullLogger.Instance);
 
             Assert.NotNull(listener);
@@ -77,6 +83,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             };
 
             var executor = new Mock<ITriggeredFunctionExecutor>();
+            var listenerConfig = new KafkaListenerConfiguration()
+            {
+                BrokerList = attribute.BrokerList,
+                Topic = attribute.Topic,
+                ConsumerGroup = "group1",
+            };
 
             var listener = KafkaListenerFactory.CreateFor(
                 attribute,
@@ -84,10 +96,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 executor.Object,
                 true,
                 new KafkaOptions(),
-                "brokers:9092",
-                "myTopic",
-                "group1",
-                null,
+                listenerConfig,
                 NullLogger.Instance);
 
             Assert.NotNull(listener);
@@ -107,17 +116,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             };
 
             var executor = new Mock<ITriggeredFunctionExecutor>();
-
+            var listenerConfig = new KafkaListenerConfiguration()
+            {
+                BrokerList = attribute.BrokerList,
+                Topic = attribute.Topic,
+                ConsumerGroup = "group1",
+            };
             var listener = KafkaListenerFactory.CreateFor(
                 attribute,
                 typeof(KafkaEventData),
                 executor.Object,
                 true,
                 new KafkaOptions(),
-                "brokers:9092",
-                "myTopic",
-                "group1",
-                null,
+                listenerConfig,
                 NullLogger.Instance);
 
             Assert.NotNull(listener);
@@ -136,17 +147,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             };
 
             var executor = new Mock<ITriggeredFunctionExecutor>();
-
+            var listenerConfig = new KafkaListenerConfiguration()
+            {
+                BrokerList = attribute.BrokerList,
+                Topic = attribute.Topic,
+                ConsumerGroup = "group1",
+            };
             var listener = KafkaListenerFactory.CreateFor(
                 attribute,
                 typeof(KafkaEventData),
                 executor.Object,
                 true,
                 new KafkaOptions(),
-                "brokers:9092",
-                "myTopic",
-                "group1",
-                null,
+                listenerConfig,
                 NullLogger.Instance);
 
             Assert.NotNull(listener);


### PR DESCRIPTION
Changes in this PR:

- Added basic authentication for trigger and output bindings #67 
- Exposing AutoCommitIntervalMs setting in host.json file
- Added tests for Kafka consumer/producer configuration based on attributes
- Added documentation on connecting to a secure Kafka broker

Pending:
- Add secure connection to e2e tests #77