### PR TITLE
Adding pdb files to the dll

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.Kafka</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.Kafka</PackageId>
     <Description>Microsoft Azure WebJobs SDK Kafka Extension</Description>
+    <DebugType>embedded</DebugType>
     <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <Authors>Microsoft</Authors>


### PR DESCRIPTION
fabio recommend me to have a pdb inclusion and source link. 

This PR is for pdb.  This configuration include the pdb file into the dll with affordable size. 
It helps a debugging a lot. azure web jobs project do the same thing. 

https://github.com/Azure/azure-webjobs-sdk-extensions/blob/7fcca7f5ce44c28b1bc9cff51592737c95c78c5f/build/common.props#L12

This conversation is easy to understand what happens. 
https://twitter.com/kirillosenkov/status/1007052524946255872?lang=en
