### PR TITLE
Updating extension version and removing package signing

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -58,30 +58,6 @@ jobs:
   - script: dotnet pack -o '$(Build.ArtifactStagingDirectory)' --include-symbols src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
     displayName: 'Pack nuget pacakge'
 
-  - task: EsrpCodeSigning@1
-    displayName: 'ESRP CodeSigning: Nupkg'
-    condition: and(succeeded(), not(variables['System.PullRequest.PullRequestNumber']))
-    inputs:
-      ConnectedServiceName: 'b12af24c-362b-4e79-bd63-61977b0007a3'
-      FolderPath: '$(Build.ArtifactStagingDirectory)'
-      Pattern: '*.nupkg'
-      signConfigType: 'inlineSignParams'
-      inlineOperation: '[
-    {
-      "KeyCode": "CP-401405",
-      "OperationCode": "NuGetSign",
-      "Parameters": {},
-      "ToolName": "sign",
-      "ToolVersion": "1.0"
-    },
-    {
-      "KeyCode": "CP-401405",
-      "OperationCode": "NuGetVerify",
-      "Parameters": {},
-      "ToolName": "sign",
-      "ToolVersion": "1.0"
-    }
-]'
   - task: PublishBuildArtifacts@1
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'

--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>0.0.1-alpha$(VersionSuffix)</Version>
+    <Version>1.0.0-alpha$(VersionSuffix)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>


### PR DESCRIPTION
This moves the extension version to 1.0.0-alpha, for publishing

Also removing the package signing as part of the regular build step as this has been moved to the release flow.