### PR TITLE
Update Confluent.Kafka to version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Azure Functions extensions for Apache Kafka
 |---|---|
 |master|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/azure-functions-kafka-extension-ci?branchName=master)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=7&branchName=master)
 
-This repository contains Kafka binding extensions for the **Azure WebJobs SDK**. The extension status is experimental/under development. The communcation with Kafka is based on library **Confluent.Kafka version 1.0.0-beta3**.
+This repository contains Kafka binding extensions for the **Azure WebJobs SDK**. The extension status is experimental/under development. The communcation with Kafka is based on library **Confluent.Kafka**.
 
 **DISCLAIMER**: This library is under development and is experimental. Currently there is no guarantee regarding support or availability as a product.
 

--- a/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
+++ b/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
@@ -5,8 +5,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0" />
   </ItemGroup>
    <ItemGroup>
     <None Update="cacert.pem">

--- a/samples/dotnet/ConsoleConsumer/MagicAvroDeserializer.cs
+++ b/samples/dotnet/ConsoleConsumer/MagicAvroDeserializer.cs
@@ -8,26 +8,25 @@ namespace ConsoleConsumer
     /// Avro deserializer that adds the magic bytes 0 and int32 in order to Confluent resolve the schema.
     /// </summary>
     /// <typeparam name="TValue"></typeparam>
-    public class MagicAvroDeserializer<TValue> : IAsyncDeserializer<TValue>
+    public class MagicAvroDeserializer<TValue> : IDeserializer<TValue>
     {
-        private readonly IAsyncDeserializer<TValue> impl;
+        private readonly IDeserializer<TValue> impl;
 
-        public MagicAvroDeserializer(IAsyncDeserializer<TValue> impl)
+        public MagicAvroDeserializer(IDeserializer<TValue> impl)
         {
             this.impl = impl;
         }
 
-        public Task<TValue> DeserializeAsync(ReadOnlyMemory<byte> data, bool isNull, SerializationContext context)
+        public TValue Deserialize(ReadOnlySpan<byte> data, bool isNull, SerializationContext context)
         {
             // TODO: find a better way to solve this
             // Allocating memory in a critical path of the trigger
             const int Prefix = sizeof(byte) + sizeof(Int32);
             var data2 = new Memory<byte>(new byte[data.Length + Prefix]);
             var data2Span = data2.Span;
-            var dataSpan = data.Span;
-            dataSpan.TryCopyTo(data2Span.Slice(Prefix));
+            data.TryCopyTo(data2Span.Slice(Prefix));
 
-            return this.impl.DeserializeAsync(data2, isNull, context);
+            return this.impl.Deserialize(data2Span, isNull, context);
         }
     }
 }

--- a/samples/dotnet/ConsoleConsumer/Program.cs
+++ b/samples/dotnet/ConsoleConsumer/Program.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Avro.Generic;
 using Confluent.Kafka;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry.Serdes;
 using Newtonsoft.Json;
 
@@ -88,7 +89,7 @@ namespace ConsoleConsumer
                 // if (typeof(TKey) != typeof(Ignore))
                 //     builder.SetKeyDeserializer(new MagicAvroDeserializer<TKey>(new AvroDeserializer<TKey>(schemaRegistry)));
 
-                builder.SetValueDeserializer(new MagicAvroDeserializer<PageViewRegion>(new AvroDeserializer<PageViewRegion>(schemaRegistry)));
+                builder.SetValueDeserializer(new MagicAvroDeserializer<PageViewRegion>(new AvroDeserializer<PageViewRegion>(schemaRegistry).AsSyncOverAsync()));
             }
 
             var consumer = builder.Build();
@@ -162,7 +163,7 @@ namespace ConsoleConsumer
                 // if (typeof(TKey) != typeof(Ignore))
                 //     builder.SetKeyDeserializer(new MagicAvroDeserializer<TKey>(new AvroDeserializer<TKey>(schemaRegistry)));
 
-                builder.SetValueDeserializer(new MagicAvroDeserializer<PageViews>(new AvroDeserializer<PageViews>(schemaRegistry)));
+                builder.SetValueDeserializer(new MagicAvroDeserializer<PageViews>(new AvroDeserializer<PageViews>(schemaRegistry).AsSyncOverAsync()));
             }
 
             var consumer = builder.Build();
@@ -237,7 +238,7 @@ namespace ConsoleConsumer
                 //     builder.SetKeyDeserializer(new MagicAvroDeserializer<TKey>(new AvroDeserializer<TKey>(schemaRegistry)));
 
 
-                builder.SetValueDeserializer(new MagicAvroDeserializer<GenericRecord>(new AvroDeserializer<GenericRecord>(schemaRegistry)));
+                builder.SetValueDeserializer(new MagicAvroDeserializer<GenericRecord>(new AvroDeserializer<GenericRecord>(schemaRegistry).AsSyncOverAsync()));
             }
 
             var consumer = builder.Build();
@@ -312,7 +313,7 @@ namespace ConsoleConsumer
                 //     builder.SetKeyDeserializer(new MagicAvroDeserializer<TKey>(new AvroDeserializer<TKey>(schemaRegistry)));
 
 
-                builder.SetValueDeserializer(new MagicAvroDeserializer<GenericRecord>(new AvroDeserializer<GenericRecord>(schemaRegistry)));
+                builder.SetValueDeserializer(new MagicAvroDeserializer<GenericRecord>(new AvroDeserializer<GenericRecord>(schemaRegistry).AsSyncOverAsync()));
             }
 
             var consumer = builder.Build();

--- a/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
+++ b/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
@@ -6,8 +6,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
   </ItemGroup>
    <ItemGroup>

--- a/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
+++ b/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
@@ -5,8 +5,8 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.26" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.27" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/dotnet/SampleHost/SampleHost.csproj
+++ b/samples/dotnet/SampleHost/SampleHost.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// Gets the value deserializer
         /// </summary>
         /// <value>The value deserializer.</value>
-        internal object ValueDeserializer { get; }
+        internal IDeserializer<TValue> ValueDeserializer { get; }
 
         public KafkaListener(
             ITriggeredFunctionExecutor executor,
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             KafkaOptions options,
             KafkaListenerConfiguration kafkaListenerConfiguration,
             bool requiresKey,
-            object valueDeserializer,
+            IDeserializer<TValue> valueDeserializer,
             ILogger logger)
         {
             this.ValueDeserializer = valueDeserializer;
@@ -88,18 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
             if (ValueDeserializer != null)
             {
-                if (ValueDeserializer is IAsyncDeserializer<TValue> asyncValueDeserializer)
-                {
-                    builder.SetValueDeserializer(asyncValueDeserializer);
-                }
-                else if (ValueDeserializer is IDeserializer<TValue> syncValueDeserializer)
-                {
-                    builder.SetValueDeserializer(syncValueDeserializer);
-                }
-                else
-                {
-                    throw new InvalidOperationException($"Value deserializer must implement either IAsyncDeserializer or IDeserializer. Type {ValueDeserializer.GetType().Name} does not");
-                }
+                builder.SetValueDeserializer(ValueDeserializer);
             }
 
             this.consumer = builder.Build();

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -32,8 +32,8 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return (ITriggerBinding)genericCreateBindingStrategy.Invoke(this, new object[] { parameterInfo, listenerConfiguration, requiresKey, valueDeserializer });
         }
 
-        private ITriggerBinding CreateBindingStrategy<TKey, TValue>(ParameterInfo parameter, KafkaListenerConfiguration listenerConfiguration, bool requiresKey, object valueDeserializer)
+        private ITriggerBinding CreateBindingStrategy<TKey, TValue>(ParameterInfo parameter, KafkaListenerConfiguration listenerConfiguration, bool requiresKey, IDeserializer<TValue> valueDeserializer)
         {
             // TODO: reuse connections if they match with others in same function app
             Task<IListener> listenerCreator(ListenerFactoryContext factoryContext, bool singleDispatch)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -27,8 +27,8 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
   </ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Helpers/KafkaListenerForTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Helpers/KafkaListenerForTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             KafkaOptions options,
             KafkaListenerConfiguration kafkaListenerConfiguration,
             bool requiresKey,
-            object valueDeserializer,
+            IDeserializer<TValue> valueDeserializer,
             ILogger logger)
             : base(executor,
                 singleDispatch,

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
@@ -3,6 +3,7 @@
 
 using Avro.Generic;
 using Confluent.Kafka;
+using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry.Serdes;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
@@ -197,7 +198,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
 
             Assert.NotNull(listener);
-            AssertIsCorrectKafkaListener(listener, expectedKeyType, typeof(GenericRecord), typeof(AvroDeserializer<GenericRecord>));            
+            AssertIsCorrectKafkaListener(listener, expectedKeyType, typeof(GenericRecord), typeof(SyncOverAsyncDeserializer<GenericRecord>));            
         }       
 
         [Theory]
@@ -234,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
 
             Assert.NotNull(listener);
-            AssertIsCorrectKafkaListener(listener, expectedKeyType, typeof(MyAvroRecord), typeof(AvroDeserializer<MyAvroRecord>));
+            AssertIsCorrectKafkaListener(listener, expectedKeyType, typeof(MyAvroRecord), typeof(SyncOverAsyncDeserializer<MyAvroRecord>));
         }
 
         [Theory]


### PR DESCRIPTION
Updating the dependency of Confluent.Kafka to official v1.0.0.

Remarks:
- There is no clean solution for Avro serializers, the library offers sync over async for now
- Update the readme, removing the version we depend on since it is not beta anymore

Would be nice to test other languages too (@TsuyoshiUshio, @priyaananthasankar)

Fixes #75 