### PR TITLE
Allow SSL certificate attribute settings to be resolved from config

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -98,10 +98,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             {
                 consumerConfig.SaslPassword = this.config.ResolveSecureSetting(nameResolver, attribute.Password);
                 consumerConfig.SaslUsername = this.config.ResolveSecureSetting(nameResolver, attribute.Username);
-                consumerConfig.SslKeyLocation = attribute.SslKeyLocation;
-                consumerConfig.SslKeyPassword = attribute.SslKeyPassword;
-                consumerConfig.SslCertificateLocation = attribute.SslCertificateLocation;
-                consumerConfig.SslCaLocation = attribute.SslCaLocation;
+                consumerConfig.SslKeyLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslKeyLocation);
+                consumerConfig.SslKeyPassword = this.config.ResolveSecureSetting(nameResolver, attribute.SslKeyPassword);
+                consumerConfig.SslCertificateLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslCertificateLocation);
+                consumerConfig.SslCaLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslCaLocation);
 
                 if (attribute.AuthenticationMode != BrokerAuthenticationMode.NotSet)
                 {


### PR DESCRIPTION
This change allows the SSL* settings in the KafkaTrigger attribute to be fetched from config/environment variables/nameresolver like the other values.