### PR TITLE
Fix librdkafka not found when running in Azure

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
@@ -111,5 +111,44 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 }
             }
         }
+
+        /// <summary>
+        /// Ensure file exists, checking for azure function base folder if not found in provided path
+        /// </summary>
+        /// <param name="filePath">The file path to validate</param>
+        /// <param name="resultFilePath">The valid file path</param>
+        /// <returns>True if the file returned by <paramref name="resultFilePath"/> exists, otherwise false</returns>
+        internal static bool TryGetValidFilePath(string filePath, out string resultFilePath)
+        {
+            resultFilePath = null;
+
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                return false;
+            }
+
+            if (File.Exists(filePath))
+            {
+                resultFilePath = filePath;
+                return true;
+            }
+
+            // try to search for in Azure function folder
+            var basePath = GetAzureFunctionBaseFolder();
+            if (string.IsNullOrWhiteSpace(basePath))
+            {
+                return false;
+            }
+
+            var filename = Path.GetFileName(filePath);
+            var filePathInAzureFunctionFolder = Path.Combine(basePath, filename);
+            if (File.Exists(filePathInAzureFunctionFolder))
+            { 
+                resultFilePath = filePathInAzureFunctionFolder;
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
     {
         internal const string AzureHomeEnvVarName = "HOME";
         internal const string AzureWebJobsScriptRootEnvVarName = "AzureWebJobsScriptRoot";
-        internal const string AzureDefaultFunctionPath = "site/wwwroot";
+        internal const string AzureDefaultFunctionPathPart1 = "site";
+        internal const string AzureDefaultFunctionPathPart2 = "wwwroot";
         internal const string AzureFunctionWorkerRuntimeEnvVarName = "FUNCTIONS_WORKER_RUNTIME";
         internal const string ProcessArchitecturex86Value = "x86";
         internal const string RuntimesFolderName = "runtimes";
@@ -61,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             var homeDir = Environment.GetEnvironmentVariable(AzureHomeEnvVarName, EnvironmentVariableTarget.Process);
             if (!string.IsNullOrWhiteSpace(homeDir))
             {
-                return Path.Combine(homeDir, AzureDefaultFunctionPath);
+                return Path.Combine(homeDir, AzureDefaultFunctionPathPart1, AzureDefaultFunctionPathPart2);
             }
 
             return null;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
@@ -1,0 +1,115 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    /// <summary>
+    /// Helper class for file related operations in functions running in Azure
+    /// </summary>
+    internal sealed class AzureFunctionsFileHelper
+    {
+        internal const string AzureHomeEnvVarName = "HOME";
+        internal const string AzureDefaultFunctionPath = "site/wwwroot";
+        internal const string AzureFunctionRuntimeVersionEnvVarName = "FUNCTIONS_EXTENSION_VERSION";
+        internal const string AzureWebSiteHostNameEnvVarName = "WEBSITE_HOSTNAME";
+        internal const string ProcessArchitecturex86Value = "x86";
+        internal const string RuntimesFolderName = "runtimes";
+        internal const string NativeFolderName = "native";
+        internal const string LibrdKafkaWindowsFileName = "librdkafka.dll";
+        internal const string LibrdKafkaLinuxFileName = "librdkafka.so";
+        internal const string Windows32ArchFolderName = "win-x86";
+        internal const string Windows64ArchFolderName = "win-x64";
+        internal const string Linux64ArchFolderName = "linux-x64";
+        internal const string OSEnvVarName = "OS";
+        internal const string SiteBitnessEnvVarName = "SITE_BITNESS";
+
+        /// <summary>
+        /// Indicates if the current excecution environment is inside a Function running in Azure
+        /// </summary>
+        internal static bool IsFunctionRunningInAzure()
+        {
+            return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(AzureFunctionRuntimeVersionEnvVarName)) &&
+                   !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(AzureWebSiteHostNameEnvVarName));
+        }
+
+        /// <summary>
+        /// Gets the Azure Function base folder
+        /// Default is D:\home\site\wwwroot
+        /// If not running in Azure as a function returns a different value
+        /// </summary>
+        internal static string GetAzureFunctionBaseFolder()
+        {
+            if (!IsFunctionRunningInAzure())
+            {
+                return null;
+            }
+                
+            // In Azure HOME contains the main folder where the function is located (windows) = D:\home
+            // By default the Azure function will be located under D:\home\site\wwwroot
+            var homeDir = Environment.GetEnvironmentVariable(AzureHomeEnvVarName, EnvironmentVariableTarget.Process);
+            if (!string.IsNullOrWhiteSpace(homeDir))
+            {
+                return Path.Combine(homeDir, AzureDefaultFunctionPath);
+            }
+
+            return null;
+        }
+
+        // Holds whether or not librdkafka has been initialized
+        static int librdkafkaInitialized;
+
+        /// <summary>
+        /// Initializes the librdkafka library from a specific place
+        /// This address the problem that running Functions in Azure won't have the current directory where the function code is.
+        /// This way we need to specifically choose the location where librdkafka is located
+        /// </summary>
+        internal static void InitializeLibrdKafka(ILogger logger)
+        {
+            // Initialize a single time
+            var originalInitializedValue = Interlocked.Exchange(ref librdkafkaInitialized, 1);
+            if (originalInitializedValue == 1)
+            {
+                return;
+            }
+
+            if (IsFunctionRunningInAzure())
+            {
+                string librdKafkaLibraryPath = null;
+
+                var os = Environment.GetEnvironmentVariable(OSEnvVarName, EnvironmentVariableTarget.Process) ?? string.Empty;
+                var isWindows = os.IndexOf("windows", 0, StringComparison.InvariantCultureIgnoreCase) != -1;
+                
+                if (isWindows)
+                {
+                    var websiteBitness = Environment.GetEnvironmentVariable(SiteBitnessEnvVarName) ?? string.Empty;
+                    var is32 = websiteBitness.Equals(ProcessArchitecturex86Value, StringComparison.InvariantCultureIgnoreCase);
+                    var architectureFolderName = is32 ? Windows32ArchFolderName : Windows64ArchFolderName;
+                    librdKafkaLibraryPath = Path.Combine(GetAzureFunctionBaseFolder(), RuntimesFolderName, architectureFolderName, NativeFolderName, LibrdKafkaWindowsFileName);
+                }
+                else
+                {
+                    // for now we just assume that is linux
+                    librdKafkaLibraryPath = Path.Combine(GetAzureFunctionBaseFolder(), RuntimesFolderName, Linux64ArchFolderName, NativeFolderName, LibrdKafkaLinuxFileName);
+                }
+
+                if (librdKafkaLibraryPath != null)
+                {
+                    if (File.Exists(librdKafkaLibraryPath))
+                    {
+                        logger.LogInformation("Loading librdkafka from {librdkafkaPath}", librdKafkaLibraryPath);
+                        Confluent.Kafka.Library.Load(librdKafkaLibraryPath);
+                    }
+                    else
+                    {
+                        logger.LogError("Did not attempt to load librdkafka because the desired file does not exist: '{librdkafkaPath}'", librdKafkaLibraryPath);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -42,6 +42,18 @@
     </PackageReference>
     <PackageReference Include="System.Threading.Channels" Version="4.5.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="cacert.pem">
+      <Pack>true</Pack>
+      <PackagePath>build</PackagePath>
+    </None>
+    <None Include="Microsoft.Azure.WebJobs.Extensions.Kafka.targets">
+      <Pack>true</Pack>
+      <PackagePath>build</PackagePath>
+    </None>
+  </ItemGroup>
+
   <ItemGroup>
     <None Update="cacert.pem">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.targets
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.targets
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)cacert.pem">
+      <Link>cacert.pem</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         public IKafkaProducer Create(KafkaProducerEntity entity)
         {
+            AzureFunctionsFileHelper.InitializeLibrdKafka(this.loggerProvider.CreateLogger(LogCategories.CreateTriggerCategory("Kafka")));
+
             // Goal is to create as less producers as possible
             // We can group producers based on following criterias
             // - Broker List

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Confluent.Kafka;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    public class AzureFunctionsFileHelperTest : IDisposable
+    {
+        Dictionary<string, string> envVarsToRestore = new Dictionary<string, string>();
+
+        private void SetEnvironmentVariable(string variable, string value)
+        {
+            if (!this.envVarsToRestore.ContainsKey(variable))
+            {
+                this.envVarsToRestore[variable] = Environment.GetEnvironmentVariable(variable);
+            }
+
+            Environment.SetEnvironmentVariable(variable, value, EnvironmentVariableTarget.Process);
+        }
+
+        void SetRunningInAzureEnvVars()
+        {
+            SetEnvironmentVariable(AzureFunctionsFileHelper.AzureFunctionRuntimeVersionEnvVarName, "~2");
+            SetEnvironmentVariable(AzureFunctionsFileHelper.AzureWebSiteHostNameEnvVarName, "kafka.azurewebsites.net");
+        }
+
+        public void Dispose()
+        {
+            foreach (var kv in envVarsToRestore)
+            {
+                Environment.SetEnvironmentVariable(kv.Key, kv.Value, EnvironmentVariableTarget.Process);
+            }
+
+            this.envVarsToRestore.Clear();
+        }
+
+        [Fact]
+        public void IsFunctionRunningInAzure_When_Does_Not_Have_Azure_EnvVars_Should_Returns_False()
+        {
+            Assert.False(AzureFunctionsFileHelper.IsFunctionRunningInAzure());
+        }
+
+        [Fact]
+        public void IsFunctionRunningInAzure_When_Does_Have_Azure_EnvVars_Should_Returns_True()
+        {
+            SetRunningInAzureEnvVars();
+            Assert.True(AzureFunctionsFileHelper.IsFunctionRunningInAzure());
+        }
+
+        [Fact]
+        public void GetAzureFunctionBaseFolder_When_Not_Running_In_Azure_Should_Return_Null()
+        {
+            Assert.Null(AzureFunctionsFileHelper.GetAzureFunctionBaseFolder());
+        }
+
+        [Fact]
+        public void GetAzureFunctionBaseFolder_When_Does_Not_Have_Home_EnvVar_Return_Null()
+        {
+            SetRunningInAzureEnvVars();
+            SetEnvironmentVariable(AzureFunctionsFileHelper.AzureHomeEnvVarName, null);
+            Assert.Null(AzureFunctionsFileHelper.GetAzureFunctionBaseFolder());
+        }
+
+        [Fact]
+        public void GetAzureFunctionBaseFolder_When_Running_In_Azure_Should_Return_Not_Null()
+        {
+            SetRunningInAzureEnvVars();
+            SetEnvironmentVariable(AzureFunctionsFileHelper.AzureHomeEnvVarName, @"d:\Home");
+
+            var actual = AzureFunctionsFileHelper.GetAzureFunctionBaseFolder();
+            Assert.NotEmpty(actual);
+            Assert.Equal(@"d:\Home/site/wwwroot", actual);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
@@ -81,7 +81,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             var actual = AzureFunctionsFileHelper.GetFunctionBaseFolder();
             Assert.NotEmpty(actual);
-            Assert.Equal(@"d:\Home\site\wwwroot", actual);
+
+            var expected = $"d:\\Home{Path.DirectorySeparatorChar}site{Path.DirectorySeparatorChar}wwwroot";
+            Assert.Equal(expected, actual);
         }
 
         [Fact]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
@@ -33,8 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
         void SetRunningInAzureEnvVars()
         {
-            SetEnvironmentVariable(AzureFunctionsFileHelper.AzureFunctionRuntimeVersionEnvVarName, "~2");
-            SetEnvironmentVariable(AzureFunctionsFileHelper.AzureWebSiteHostNameEnvVarName, "kafka.azurewebsites.net");
+            SetEnvironmentVariable(AzureFunctionsFileHelper.AzureFunctionWorkerRuntimeEnvVarName, "dotnet");            
         }
 
         public void Dispose()
@@ -82,7 +81,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             var actual = AzureFunctionsFileHelper.GetFunctionBaseFolder();
             Assert.NotEmpty(actual);
-            Assert.Equal(@"d:\Home/site/wwwroot", actual);
+            Assert.Equal(@"d:\Home\site\wwwroot", actual);
+        }
+
+        [Fact]
+        public void GetAzureFunctionBaseFolder_When_Running_In_Container_Should_Return_Not_Null()
+        {
+            const string pathInContainer = @"home/site/wwwroot";
+
+            SetRunningInAzureEnvVars();
+            SetEnvironmentVariable(AzureFunctionsFileHelper.AzureWebJobsScriptRootEnvVarName, pathInContainer);
+
+            var actual = AzureFunctionsFileHelper.GetFunctionBaseFolder();
+            Assert.NotEmpty(actual);
+            Assert.Equal(pathInContainer, actual);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
@@ -50,20 +50,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         [Fact]
         public void IsFunctionRunningInAzure_When_Does_Not_Have_Azure_EnvVars_Should_Returns_False()
         {
-            Assert.False(AzureFunctionsFileHelper.IsFunctionRunningInAzure());
+            Assert.False(AzureFunctionsFileHelper.IsRunningAsFunctionInAzureOrContainer());
         }
 
         [Fact]
         public void IsFunctionRunningInAzure_When_Does_Have_Azure_EnvVars_Should_Returns_True()
         {
             SetRunningInAzureEnvVars();
-            Assert.True(AzureFunctionsFileHelper.IsFunctionRunningInAzure());
+            Assert.True(AzureFunctionsFileHelper.IsRunningAsFunctionInAzureOrContainer());
         }
 
         [Fact]
         public void GetAzureFunctionBaseFolder_When_Not_Running_In_Azure_Should_Return_Null()
         {
-            Assert.Null(AzureFunctionsFileHelper.GetAzureFunctionBaseFolder());
+            Assert.Null(AzureFunctionsFileHelper.GetFunctionBaseFolder());
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         {
             SetRunningInAzureEnvVars();
             SetEnvironmentVariable(AzureFunctionsFileHelper.AzureHomeEnvVarName, null);
-            Assert.Null(AzureFunctionsFileHelper.GetAzureFunctionBaseFolder());
+            Assert.Null(AzureFunctionsFileHelper.GetFunctionBaseFolder());
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             SetRunningInAzureEnvVars();
             SetEnvironmentVariable(AzureFunctionsFileHelper.AzureHomeEnvVarName, @"d:\Home");
 
-            var actual = AzureFunctionsFileHelper.GetAzureFunctionBaseFolder();
+            var actual = AzureFunctionsFileHelper.GetFunctionBaseFolder();
             Assert.NotEmpty(actual);
             Assert.Equal(@"d:\Home/site/wwwroot", actual);
         }


### PR DESCRIPTION
Running a function using the extension in Azure current does not work. The host cannot start because the extension fails to load librdkadka.

After investigation, I believe this happens because the current directory when running in Azure is not the function output folder (which is true when debugging locally). To handle this, I am loading the library from an explicit location.

I am using environment variables, and known information (i.e. d:\Home\sites\wwwroot being the base path) to resolve the location. I wonder if there is a better way to do it.

I also include the cacert.pem file as part of the nuget package as this is a requirement when using Event Hubs with Kafka header.

Fixes #110 