### PR TITLE
Commit single dispatch after each function call

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
@@ -44,14 +44,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                         var offsetsToCommit = new Dictionary<int, TopicPartitionOffset>();
                         for (var i=itemsToExecute.Length - 1; i >= 0; i--)
                         {
-                            if (!offsetsToCommit.ContainsKey(itemsToExecute[i].Partition))
+                            var currentItem = itemsToExecute[i];
+                            if (!offsetsToCommit.ContainsKey(currentItem.Partition))
                             {
                                 offsetsToCommit.Add(
-                                    itemsToExecute[i].Partition, 
+                                    currentItem.Partition, 
                                     new TopicPartitionOffset(
-                                        itemsToExecute[i].Topic,
-                                        itemsToExecute[i].Partition,
-                                        itemsToExecute[i].Offset + 1)); // offset is inclusive when resuming
+                                        currentItem.Topic,
+                                        currentItem.Partition,
+                                        currentItem.Offset + 1)); // offset is inclusive when resuming
                             }
                         }
 


### PR DESCRIPTION
Function executions are dispatched in two ways:

- Multiple items 
  - Trigger function receives a collection of events (from 1 or more partitions)
  - A single function call is executed for whole batch
  - Checkpoint happens after the function call returns

- Single items
  - Trigger function receives one event
  - One function call per event, parallelize by partition
  - Checkpoint happens after all function calls succeeded

With the upcoming introduction of a scaler, the fact that the checkpoint for single dispatch happens only once all calls are completed causes a delay in updating the consumer lag, specially if the function execution takes too long and the batch size is big.

To have a more accurate consumer lag metrics the following changes for single dispatching are being introduced:
- 1 task per partition contained in the message batch is created
- Once function call returns (with a single event) we commit the partition offset