### PR TITLE
Adding cardinality support for Java Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,14 @@ Both, trigger and output, can connect to a secure Kafka broker. The following at
 
 Username and password should reference a Azure function configuration variable and not be hardcoded.
 
+## Language support configuration
+
+For the non-C# languages, you can specify `cardinality` for choosing if the KafkaTrigger is executed in batch. 
+|Setting|Description|Option|
+|-|-|-|
+|cardinality|Set to many in order to enable batching. If omitted or set to one, a single message is passed to the function. For Java functions, if you set "MANY", you need to set a `dataType`. |"ONE", "MANY"|
+|dataType|For java functions, the type of the deserialize a kafka event. It requires when you use cardinality = "MANY" |"string", "binary", "stream"|
+
 ## Linux Premium plan configuration
 Currently when running a function in a Linux Premium plan environment there will be an error indicating that we could not load the librdkafka library. To address the problem, at least for now, please add the setting below. It will include the extension location as one of the paths where libraries are searched. We are working on avoiding this setting in future releases.
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ For the non-C# languages, you can specify `cardinality` for choosing if the Kafk
 |Setting|Description|Option|
 |-|-|-|
 |cardinality|Set to many in order to enable batching. If omitted or set to one, a single message is passed to the function. For Java functions, if you set "MANY", you need to set a `dataType`. |"ONE", "MANY"|
-|dataType|For java functions, the type of the deserialize a kafka event. It requires when you use cardinality = "MANY" |"string", "binary", "stream"|
+|dataType|For java functions, the type of the deserialize a kafka event. It requires when you use cardinality = "MANY" |"string", "binary"|
 
 ## Linux Premium plan configuration
 Currently when running a function in a Linux Premium plan environment there will be an error indicating that we could not load the librdkafka library. To address the problem, at least for now, please add the setting below. It will include the extension location as one of the paths where libraries are searched. We are working on avoiding this setting in future releases.

--- a/binding-library/java/src/main/java/com/microsoft/azure/functions/kafka/annotation/KafkaTrigger.java
+++ b/binding-library/java/src/main/java/com/microsoft/azure/functions/kafka/annotation/KafkaTrigger.java
@@ -9,6 +9,8 @@ import com.microsoft.azure.functions.annotation.CustomBinding;
 import com.microsoft.azure.functions.kafka.BrokerAuthenticationMode;
 import com.microsoft.azure.functions.kafka.BrokerProtocol;
 
+import com.microsoft.azure.functions.annotation.Cardinality;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.annotation.RetentionPolicy;
@@ -36,6 +38,20 @@ public @interface KafkaTrigger {
      * Gets or sets the EventHub connection string when using KafkaOutput protocol header feature of Azure EventHubs.
      */
     String eventHubConnectionString() default "";
+    /**
+     * Cardinality of the trigger input.
+     * Choose 'One' if the input is a single message or 'Many' if the input is an array of messages.
+     * If you choose 'Many', please set a dataType. 
+     * Default: 'One'
+     */
+    Cardinality cardinality() default Cardinality.ONE;
+    /**
+     * DataType for the Cardinality settings. If you set the cardinality as Cardinality.MANY, Azure Functions Host will deserialize
+     * the kafka events as an array of this type.
+     * Allowed values: string, binary, stream
+     * Default: ""
+     */
+    String dataType() default "";
 
     /**
      * Gets or sets the consumer group.
@@ -47,7 +63,7 @@ public @interface KafkaTrigger {
      * Allowed values: Gssapi, Plain, ScramSha256, ScramSha512
      * Default: PLAIN
      */
-    BrokerAuthenticationMode authenticationMode() default BrokerAuthenticationMode.NOTSET; // TODO double check if it is OK
+    BrokerAuthenticationMode authenticationMode() default BrokerAuthenticationMode.NOTSET;
 
     /**
      * SASL username with the PLAIN and SASL-SCRAM-.. mechanisms

--- a/samples/java/README.MD
+++ b/samples/java/README.MD
@@ -46,7 +46,13 @@ Go to the Azure Functions directory that is created by the package command. Plea
 
 ```
 $ cd target/azure-functions/kafka-function-20190419163130420/
-$ func extensions install Microsoft.Azure.WebJobs.Extensions.Kafka --version 2.0.0-beta
+$ func extensions --package install Microsoft.Azure.WebJobs.Extensions.Kafka --version 2.0.0-beta
+```
+
+For mac or linux users, you can do the same thing with 
+
+```bash
+$ ./install_extension.sh
 ```
 
 Check if there is dll packages under the `target/azure-functions/kafka-function-(some number)/bin`. If it is sucess, you will find `Microsoft.Azure.WebJobs.Extensions.Kafka.dll` on it. 

--- a/samples/java/install_extension.sh
+++ b/samples/java/install_extension.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# TODO remove this shell program once Extension Bundle is supporeted. 
+
+pushd . 
+cd target/azure-functions/kafka-function-20190419163130420/
+func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 2.0.0-beta
+popd 

--- a/samples/java/src/main/java/com/contoso/kafka/FunctionOutput.java
+++ b/samples/java/src/main/java/com/contoso/kafka/FunctionOutput.java
@@ -11,6 +11,13 @@ import com.microsoft.azure.functions.kafka.*;
 import java.util.Optional;
 
 public class FunctionOutput {
+    /**
+     * This function listens at endpoint "api/KafkaInput-Java" and send message to the conluent-topic. Two ways to invoke it using "curl" command in bash:
+     * 1. curl -d "HTTP BODY" {your host}/api/KafkaInput-Java
+     * 2. curl "{your host}/api/KafkaInput-Java?message=hello"
+     * This sample is for a local cluster. Modify topic and brokerList on the @KafkaOutput annotataion
+     * For the Confluence Cloud example, please refer the KafkaTrigger-Java-Many on the `TriggerFunction.java`.
+     */
     @FunctionName("KafkaInput-Java")
     public HttpResponseMessage input(
             @HttpTrigger(name = "req", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,

--- a/samples/java/src/main/java/com/contoso/kafka/TriggerFunction.java
+++ b/samples/java/src/main/java/com/contoso/kafka/TriggerFunction.java
@@ -12,18 +12,42 @@ import com.microsoft.azure.functions.kafka.*;
  */
 public class TriggerFunction {
     /**
-     * This function listens at endpoint "/api/HttpTrigger-Java". Two ways to invoke it using "curl" command in bash:
-     * 1. curl -d "HTTP Body" {your host}/api/HttpTrigger-Java&code={your function key}
-     * 2. curl "{your host}/api/HttpTrigger-Java?name=HTTP%20Query&code={your function key}"
-     * TriggerFunction Key is not needed when running locally, it is used to invoke function deployed to Azure.
-     * More details: https://aka.ms/functions_authorization_keys
+     * This function consume KafkaEvents on the localhost. Change the topic, brokerList, and consumerGroup to fit your enviornment.
+     * The function is trigged one for each KafkaEvent
+     * @param kafkaEventData
+     * @param context
      */
-
     @FunctionName("KafkaTrigger-Java")
-    public void run(
+    public void runOne(
             @KafkaTrigger(topic = "my-confluent-topic", brokerList="localhost:31090",consumerGroup="$Default") String kafkaEventData,
             final ExecutionContext context) {
         context.getLogger().info(kafkaEventData);
     }
 
+    /**
+     * This function consume KafkaEvents on the confluent cloud. Create a local.settings.json or configure AppSettings for configring
+     * BrokerList and UserName, and Password. The value wrapped with `%` will be replaced with enviornment variables. 
+     * For more details, refer https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-expressions-patterns#binding-expressions---app-settings
+     * The function is a sample of consuming kafkaEvent on batch.
+     * @param kafkaEventData
+     * @param context
+     */
+    @FunctionName("KafkaTrigger-Java-Many")
+    public void runMany(
+            @KafkaTrigger(
+                topic = "message", 
+                brokerList="%BrokerList%",
+                consumerGroup="$Default", 
+                username = "%UserName%", 
+                password = "%Password%",
+                authenticationMode = BrokerAuthenticationMode.PLAIN,
+                protocol = BrokerProtocol.SASLSSL,
+                cardinality = Cardinality.MANY,
+                dataType = "string"
+             ) String[] kafkaEventData,
+            final ExecutionContext context) {
+            for (String message: kafkaEventData) {
+                context.getLogger().info(message);
+            }    
+    }
 }

--- a/samples/java/src/repo/com/microsoft/azure/functions/azure-functions-java-library-kafka/maven-metadata-local.xml
+++ b/samples/java/src/repo/com/microsoft/azure/functions/azure-functions-java-library-kafka/maven-metadata-local.xml
@@ -7,6 +7,6 @@
     <versions>
       <version>1.0.0</version>
     </versions>
-    <lastUpdated>20190425205411</lastUpdated>
+    <lastUpdated>20200605204247</lastUpdated>
   </versioning>
 </metadata>


### PR DESCRIPTION
This PR includes cardinality support for following the standard of EventHub.
https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger?tabs=javascript#configuration

# Overview

The cardinality is supported on the Functions Host side. If you set the Cardinality as Many, you need to set `dataType` as well. It is used for de-serialize the Kafka event to be the type of KafkaTrigger function. We can choose `string`, `binary`, `stream` as a `dataType`. I also consider if I should create `DataType` enum.  I follow the solution of the EventHub. They use string as the  `dataType`. 

# Includes 
* Cardinality support on Annotation
* Cardinality and Confluence support sample
* Document update and small bug fix
* Cardinality sample is tested and run with Confluent cloud

# Next step 
For the Java users, I'd like to write `Getting Started` and reference documentation. For the GA, it might help the customers since building the Kafka development environment is slightly complex. 

# Additional Note
The documentation doesn't mention `dataType`.  I create an issue for it. 
https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger?tabs=javascript#configuration

Currently, E2E of cardinality Many is commented. 
https://github.com/Azure/azure-functions-java-worker/blob/dev/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsEndToEndTests.cs#L134