### PR TITLE
Enable app setting binding expression for consumer group and topic

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -89,8 +89,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             var consumerConfig = new KafkaListenerConfiguration()
             {
                 BrokerList = this.config.ResolveSecureSetting(nameResolver, attribute.BrokerList),
-                ConsumerGroup = this.nameResolver.ResolveWholeString(attribute.ConsumerGroup),
-                Topic = this.nameResolver.ResolveWholeString(attribute.Topic),
+                ConsumerGroup = this.config.ResolveSecureSetting(nameResolver, attribute.ConsumerGroup),
+                Topic = this.config.ResolveSecureSetting(nameResolver, attribute.Topic),
                 EventHubConnectionString = this.config.ResolveSecureSetting(nameResolver, attribute.EventHubConnectionString),
             };
 


### PR DESCRIPTION
This is requested from this issue. 
https://github.com/Azure/azure-functions-kafka-extension/issues/148

Enabling Binding expression for the `topic` and `consumer group`. 

* [Binding expressions - app settings](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-expressions-patterns)

We can configure the kafka trigger with `%NAME%` and you can configure the value on your app settings or local.settings.json.

```csharp
       [FunctionName(nameof(StringTopic))]
        public static void StringTopic(
            [KafkaTrigger("%broker%", "stringTopic", ConsumerGroup = "%consumerGroup%")] KafkaEventData<string> kafkaEvent,
            ILogger logger)
        {
            logger.LogInformation(kafkaEvent.Value.ToString());
        }
```