### PR TITLE
Bump version and Add EventHubs sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,18 +389,6 @@ public static class ConfluentCloudTrigger
 site.
 **ConfluentCloudPassword**: is you API secret, obtained from the Confluent Cloud web site.
 
-
-**NOTE:** Microsoft.Azure.WebJobs.Extensions.Kafka (3.1.0)+ doesn't require CA certification location.
-
-3. (Deprecated) Download and set the CA certification location. As described in [Confluent documentation](https://github.com/confluentinc/examples/tree/5.4.0-post/clients/cloud/csharp#produce-records), the .NET library does not have the capability to access root CA certificates.<br>
-Missing this step will cause your function to raise the error "sasl_ssl://xyz-xyzxzy.westeurope.azure.confluent.cloud:9092/bootstrap: Failed to verify broker certificate: unable to get local issuer certificate (after 135ms in state CONNECT)"<br>
-To overcome this, we need to:
-    - Download CA certificate (i.e. from https://curl.haxx.se/ca/cacert.pem).
-    - Rename the certificate file to anything other than cacert.pem to avoid any conflict with existing EventHubs Kafka certificate that is part of the extension.
-    - Include the file in the project, setting "copy to output directory"
-    - Set the SslCaLocation trigger attribute property. In the example we set to `confluent_cloud_cacert.pem`
-
-
 ## Testing
 
 This repo includes unit and end to end tests. End to end tests require a Kafka instance. A quick way to provide one is to use the Kafka quick start example mentioned previously or use a simpler single node docker-compose solution (also based on Confluent Docker images):

--- a/README.md
+++ b/README.md
@@ -374,8 +374,7 @@ public static class ConfluentCloudTrigger
             Protocol = BrokerProtocol.SaslSsl,
             AuthenticationMode = BrokerAuthenticationMode.Plain,
             Username = "ConfluentCloudUsername",
-            Password = "ConfluentCloudPassword",
-            SslCaLocation = "confluent_cloud_cacert.pem")]
+            Password = "ConfluentCloudPassword")]
         KafkaEventData<string> kafkaEvent,
         ILogger logger)
     {
@@ -390,7 +389,10 @@ public static class ConfluentCloudTrigger
 site.
 **ConfluentCloudPassword**: is you API secret, obtained from the Confluent Cloud web site.
 
-3. Download and set the CA certification location. As described in [Confluent documentation](https://github.com/confluentinc/examples/tree/5.4.0-post/clients/cloud/csharp#produce-records), the .NET library does not have the capability to access root CA certificates.<br>
+
+**NOTE:** Microsoft.Azure.WebJobs.Extensions.Kafka (3.1.0)+ doesn't require CA certification location.
+
+3. (Deprecated) Download and set the CA certification location. As described in [Confluent documentation](https://github.com/confluentinc/examples/tree/5.4.0-post/clients/cloud/csharp#produce-records), the .NET library does not have the capability to access root CA certificates.<br>
 Missing this step will cause your function to raise the error "sasl_ssl://xyz-xyzxzy.westeurope.azure.confluent.cloud:9092/bootstrap: Failed to verify broker certificate: unable to get local issuer certificate (after 135ms in state CONNECT)"<br>
 To overcome this, we need to:
     - Download CA certificate (i.e. from https://curl.haxx.se/ca/cacert.pem).

--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>3.0.0$(VersionSuffix)</Version>
+    <Version>3.1.0$(VersionSuffix)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>

--- a/samples/README.md
+++ b/samples/README.md
@@ -157,8 +157,6 @@ You can find the configuration for the Confluent Cloud for C# in
 [Connecting to Confluent Cloud in Azure](https://github.com/Azure/azure-functions-kafka-extension#connecting-to-confluent-cloud-in-azure).
 
 
-On Windows, you need to include `confluent_cloud_cacert.pem` to reference the CA certificate for accessing Confluent Cloud. You can use `sslCaLocation` to set the path to the certificate.  
-
 ### Install binding library (Java/Python)
 Java and Python have a binding library. Currently, it resides in this repository. In the near feature, it will move to the official repo. So you don't need to install manually. 
 

--- a/samples/dotnet/KafkaFunctionSample/SimpleKafkaTriggers.cs
+++ b/samples/dotnet/KafkaFunctionSample/SimpleKafkaTriggers.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using Microsoft.Azure.WebJobs.Extensions.Kafka;
+using Avro;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.IO;
+
+namespace KafkaFunctionSample
+{
+    public class SimpleKafkaTriggers
+    {
+        [FunctionName(nameof(SampleConsumer))]
+        public void SampleConsumer(
+    [KafkaTrigger(
+            "LocalBroker", 
+            "myeventhub", 
+            ConsumerGroup = "$Default",
+            Username = "$ConnectionString",
+            Password = "%EventHubConnectionString%",
+            Protocol = BrokerProtocol.SaslSsl,
+            AuthenticationMode = BrokerAuthenticationMode.Plain)] KafkaEventData<string> kafkaEvent,
+    ILogger logger)
+        {
+            logger.LogInformation(kafkaEvent.Value.ToString());
+        }
+
+        [FunctionName(nameof(SampleProducer))]
+        public IActionResult SampleProducer(
+        [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
+        [Kafka(
+            "LocalBroker",
+            "myeventhub",
+            Username = "$ConnectionString",
+            Password = "%EventHubConnectionString%",
+            Protocol = BrokerProtocol.SaslSsl,
+            AuthenticationMode = BrokerAuthenticationMode.Plain)] out KafkaEventData<string>[] kafkaEventData,
+        ILogger logger)
+        {
+            var data = new StreamReader(req.Body).ReadToEnd();
+            kafkaEventData = new[] {
+                    new KafkaEventData<string>()
+                    {
+                        Value = data + ":1:" + DateTime.UtcNow.Ticks,
+                    },
+                    new KafkaEventData<string>()
+                    {
+                        Value = data + ":2:" + DateTime.UtcNow.Ticks,
+                    },
+                };
+            return new OkResult();
+        }
+    }
+}

--- a/samples/dotnet/README.md
+++ b/samples/dotnet/README.md
@@ -65,6 +65,8 @@ A sample function is provided in samples/dotnet/KafkaFunctionSample/SimpleKafkaT
 }
 ```
 
+For more configuration details for EventHubs, refer to the [Use Azure Event Hubs from Apache Kafka applications: Shared Access Signature (SAS)](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-for-kafka-ecosystem-overview#shared-access-signature-sas)
+
 ## Test
 
 Restore, Build, and Debug `KafkaFunctionSample`.

--- a/samples/dotnet/README.md
+++ b/samples/dotnet/README.md
@@ -31,7 +31,7 @@ If you have problems connecting to localhost:9092 try to add `broker    127.0.0.
 
 # Quick Start
 
-You can refer [Quick Start](https://github.com/Azure/azure-functions-kafka-extension#quickstart) on the top page
+You can refer [Quick Start](https://github.com/Azure/azure-functions-kafka-extension#net-quickstart) on the top page
 
 # Test
 
@@ -42,4 +42,36 @@ with JSON Body and ContentType = `application/json`.
 
 ```json
 {"hello":"world"}
+```
+
+# EventHubs Sample
+Event Hubs provides a Kafka endpoint that can be used by the Kafka extension. For more details, refer to 
+
+* [Use Azure Event Hubs from Apache Kafka applications](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-for-kafka-ecosystem-overview)
+
+## Configuration
+
+A sample function is provided in samples/dotnet/KafkaFunctionSample/SimpleKafkaTriggers.cs. Follow the direction of [Quickstart: Create an event hub using Azure portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create) Add a local.settings.json files that looks like this:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "None",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    "LocalBroker": "YOUR_EVENTHUBS_NAMESPACE.servicebus.windows.net:9093",
+    "EventHubConnectionString": "YOUR_EVENTHUBS_CONNECTION_STRING"
+  }
+}
+```
+
+## Test
+
+Restore, Build, and Debug `KafkaFunctionSample`.
+
+POST request `http://localhost:7071/api/SampleProducer` 
+with raw Body like following.
+
+```
+hello
 ```


### PR DESCRIPTION
I upgrade the Kafka extension for the next release with EventHubs sample. 

## What I did 
* Add EventHubs sample 
* Update the documentation related `ca.cert` except for language samples. 

## Todo
* Languages sample/documentation update

For language support, we don't need the `ca.cert` anymore, however, for the testing, we need published nuget.
I'll do this after publish the new version.