### PR TITLE
Output Binding Topic Support AppSettings

### DIFF
--- a/samples/dotnet/KafkaFunctionSample/SimpleKafkaTriggers.cs
+++ b/samples/dotnet/KafkaFunctionSample/SimpleKafkaTriggers.cs
@@ -15,8 +15,8 @@ namespace KafkaFunctionSample
         [FunctionName(nameof(SampleConsumer))]
         public void SampleConsumer(
     [KafkaTrigger(
-            "LocalBroker", 
-            "myeventhub", 
+            "LocalBroker",
+            "%EHTOPIC%",
             ConsumerGroup = "$Default",
             Username = "$ConnectionString",
             Password = "%EventHubConnectionString%",
@@ -32,7 +32,7 @@ namespace KafkaFunctionSample
         [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
         [Kafka(
             "LocalBroker",
-            "myeventhub",
+            "%EHTOPIC%",
             Username = "$ConnectionString",
             Password = "%EventHubConnectionString%",
             Protocol = BrokerProtocol.SaslSsl,

--- a/samples/dotnet/README.md
+++ b/samples/dotnet/README.md
@@ -60,6 +60,7 @@ A sample function is provided in samples/dotnet/KafkaFunctionSample/SimpleKafkaT
     "AzureWebJobsStorage": "None",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "LocalBroker": "YOUR_EVENTHUBS_NAMESPACE.servicebus.windows.net:9093",
+    "EHTOPIC": "YOUR_EVENT_HUB_NAME",
     "EventHubConnectionString": "YOUR_EVENTHUBS_CONNECTION_STRING"
   }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaExtensionConfigProvider.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 .BindToTrigger(triggerBindingProvider);
 
             // register output binding
-            context.AddBindingRule<KafkaAttribute>().Bind(new KafkaAttributeBindingProvider(this.kafkaProducerFactory));
+            context.AddBindingRule<KafkaAttribute>().Bind(new KafkaAttributeBindingProvider(config, nameResolver, this.kafkaProducerFactory));
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttributeBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttributeBinding.cs
@@ -4,6 +4,7 @@
 using Confluent.Kafka;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Threading.Tasks;
 
@@ -19,6 +20,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         private readonly Type keyType;
         private readonly Type valueType;
         private readonly string avroSchema;
+        private readonly IConfiguration config;
+        private readonly INameResolver nameResolver;
 
         public KafkaAttributeBinding(
             string parameterName, 
@@ -27,7 +30,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             IArgumentBinding<KafkaProducerEntity> argumentBinding,
             Type keyType,
             Type valueType,
-            string avroSchema)
+            string avroSchema,
+            IConfiguration config,
+            INameResolver nameResolver)
         {
             this.parameterName = parameterName;
             this.attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
@@ -36,6 +41,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             this.keyType = keyType;
             this.valueType = valueType ?? throw new ArgumentNullException(nameof(valueType));
             this.avroSchema = avroSchema;
+            this.config = config;
+            this.nameResolver = nameResolver;
         }
 
         public bool FromAttribute => true;
@@ -49,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 KafkaProducerFactory = this.kafkaProducerFactory,
                 KeyType = this.keyType ?? typeof(Null),
                 ValueType = this.valueType,
-                Topic = this.attribute.Topic,
+                Topic = this.config.ResolveSecureSetting(this.nameResolver, this.attribute.Topic),
                 Attribute = this.attribute,
                 AvroSchema = this.avroSchema,
             };
@@ -66,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 KafkaProducerFactory = this.kafkaProducerFactory,
                 KeyType = this.keyType ?? typeof(Null),
                 ValueType = this.valueType,
-                Topic = this.attribute.Topic,
+                Topic = this.config.ResolveSecureSetting(this.nameResolver, this.attribute.Topic),
                 Attribute = this.attribute,
                 AvroSchema = this.avroSchema,
             };

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttributeBindingProvider.cs
@@ -3,6 +3,7 @@
 
 using Confluent.Kafka;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -20,10 +21,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             );
 
         private readonly IKafkaProducerFactory kafkaProducerFactory;
+        private readonly IConfiguration config;
+        private readonly INameResolver nameResolver;
 
-        public KafkaAttributeBindingProvider(IKafkaProducerFactory kafkaProducerFactory)
+        public KafkaAttributeBindingProvider(IConfiguration config, INameResolver nameResolver, IKafkaProducerFactory kafkaProducerFactory)
         {
             this.kafkaProducerFactory = kafkaProducerFactory;
+            this.config = config;
+            this.nameResolver = nameResolver;
         }
 
         public Task<IBinding> TryCreateAsync(BindingProviderContext context)
@@ -51,7 +56,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 argumentBinding,
                 keyAndValueTypes.KeyType,
                 keyAndValueTypes.ValueType,
-                keyAndValueTypes.AvroSchema);
+                keyAndValueTypes.AvroSchema,
+                this.config,
+                this.nameResolver);
             return Task.FromResult<IBinding>(binding);
         }
     }


### PR DESCRIPTION
Enabled to reference the KafkaOutput binding to use reference resolution. 

_functions_

```csharp
        [FunctionName(nameof(SampleProducer))]
        public IActionResult SampleProducer(
        [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
        [Kafka(
            "LocalBroker",
            "%EHTOPIC%",
            Username = "$ConnectionString",
            Password = "%EventHubConnectionString%",
            Protocol = BrokerProtocol.SaslSsl,
            AuthenticationMode = BrokerAuthenticationMode.Plain)] out KafkaEventData<string>[] kafkaEventData,
        ILogger logger)
        {
                        : 
        }
```

_local.settings.json_

```json
{
  "IsEncrypted": false,
  "Values": {
    "AzureWebJobsStorage": "None",
    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
    "LocalBroker": "YOUR_NAMESPACE.servicebus.windows.net:9093",
    "EHTOPIC": "myeventhub",
    "EventHubConnectionString": "YOUR_CONNECTION_STRING"
  }
}
```

# Fix
https://github.com/Azure/azure-functions-kafka-extension/issues/158
