### PR TITLE
Remove the PackageLicenseUrl for deprecation

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -13,11 +13,11 @@
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2028464</PackageLicenseUrl>
     <PackageProjectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/azure-functions-kafka-extension</RepositoryUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION
The Release pipeline has been failed. The root cause was, LicenseUrl becomes, deprecated. That prevents to create nuget file. 

For more details, refer to 

* [Adding license details to NuGet packages](https://www.flexlabs.org/2019/05/adding-license-details-to-nuget-packages)
* [Azure Functions Host: package.props](https://github.com/Azure/azure-functions-host/blob/8abc744eb19e382badcb266215006432ff4939ad/build/package.props)

## Before

```cmd
dotnet pack -o . --include-symbols src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
Microsoft (R) Build Engine version 16.7.0+b89cb5fde for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  Microsoft.Azure.WebJobs.Extensions.Kafka -> C:\Users\tsushi\Code\kafkaga\azure-functions-kafka-extension\src\Microsoft.Azure.WebJobs.Extensions.Kafka\bin\Debug\netstandard2.0\Microsoft.Azure.WebJobs.Extensions.Kafka.dll
C:\Program Files\dotnet\sdk\3.1.401\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(198,5): error NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. [C:\Users\tsushi\Code\kafkaga\azure-functions-kafka-extension\src\Microsoft.Azure.WebJobs.Extensions.Kafka\Microsoft.Azure.WebJobs.Extensions.Kafka.csproj]
  Successfully created package 'C:\Users\tsushi\Code\kafkaga\azure-functions-kafka-extension\Microsoft.Azure.WebJobs.Extensions.Kafka.3.1.0.symbols.nupkg'.
```

## After this fix

```cmd
dotnet pack -o . --include-symbols src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
Microsoft (R) Build Engine version 16.7.0+b89cb5fde for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  Microsoft.Azure.WebJobs.Extensions.Kafka -> C:\Users\tsushi\Code\kafkaga\azure-functions-kafka-extension\src\Microsoft.Azure.WebJobs.Extensions.Kafka\bin\Debug\netstandard2.0\Microsoft.Azure.WebJobs.Extensions.Kafka.dll
  Successfully created package 'C:\Users\tsushi\Code\kafkaga\azure-functions-kafka-extension\Microsoft.Azure.WebJobs.Extensions.Kafka.3.1.0.nupkg'.
  Successfully created package 'C:\Users\tsushi\Code\kafkaga\azure-functions-kafka-extension\Microsoft.Azure.WebJobs.Extensions.Kafka.3.1.0.symbols.nupkg'.
```