### PR TITLE
Allow specifying attribute configuration using a "connection string"

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
@@ -13,8 +13,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
     [Binding]
-    public sealed class KafkaAttribute : Attribute
+    public sealed class KafkaAttribute : Attribute, IAttributeWithConfigurationString
     {
+        private readonly string configurationString;
+
         /// <summary>
         /// Initialize a new instance of the <see cref="KafkaAttribute"/>
         /// </summary>
@@ -24,6 +26,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         {
             BrokerList = brokerList;
             Topic = topic;
+        }
+
+        public KafkaAttribute(string brokerList, string topic, string configurationString) : this(brokerList, topic)
+        {
+            this.configurationString = configurationString;
         }
 
         /// <summary>
@@ -139,5 +146,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// ssl.key.password in librdkafka
         /// </summary>
         public string SslKeyPassword { get; set; }
+
+        string IAttributeWithConfigurationString.ConfigurationString => configurationString;
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttributeBindingProvider.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             {
                 return Task.FromResult<IBinding>(null);
             }
-            
+
+            new AttributeEnricher().Enrich(attribute, config, nameResolver);
 
             var argumentBinding = InnerProvider.TryCreate(parameter);
             var keyAndValueTypes = SerializationHelper.GetKeyAndValueTypes(attribute.AvroSchema, parameter.ParameterType, typeof(Null));

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/AttributeEnricher.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/AttributeEnricher.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Data.Common;
+using System.Globalization;
+using System.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    internal class AttributeEnricher
+    {
+        public virtual void Enrich<T>(T attribute, IConfiguration config, INameResolver nameResolver) where T : IAttributeWithConfigurationString
+        {
+
+            if (!string.IsNullOrWhiteSpace(attribute.ConfigurationString))
+            {
+                var builder = new DbConnectionStringBuilder();
+                builder.ConnectionString = attribute.ConfigurationString;
+                foreach (string key in builder.Keys)
+                {
+                    var prop = typeof(T).GetProperties().Where(x => x.CanWrite).Where(x => x.Name.Equals(key, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                    if (prop != null)
+                    {
+                        var propertyType = prop.PropertyType;
+                        if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                        {
+                            propertyType = propertyType.GetGenericArguments()[0];
+                        }
+                        var value = Convert.ToString(builder[key]);
+                        value = config.ResolveSecureSetting(nameResolver, value);
+                        object propValue = null;
+                        if (propertyType.IsEnum)
+                        {
+                            propValue = Enum.Parse(propertyType, value, true);
+                        }
+                        else
+                        {
+                            propValue = Convert.ChangeType(value, propertyType, CultureInfo.InvariantCulture);
+                        }
+                        prop.SetValue(attribute, propValue);
+                    }
+                }
+            }
+        }         
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/IAttributeWithConfigurationString.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/IAttributeWithConfigurationString.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    internal interface IAttributeWithConfigurationString
+    {
+        internal string ConfigurationString { get; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttribute.cs
@@ -13,13 +13,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
     [Binding]
-    public class KafkaTriggerAttribute : Attribute
+    public class KafkaTriggerAttribute : Attribute, IAttributeWithConfigurationString
     {
+        private string configurationString;
 
         public KafkaTriggerAttribute(string brokerList, string topic)
         {
             this.BrokerList = brokerList;
             this.Topic = topic;
+        }
+
+        public KafkaTriggerAttribute(string brokerList, string topic, string configurationString) : this(brokerList, topic)
+        {
+            this.configurationString = configurationString;
         }
 
         /// <summary>
@@ -41,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// Gets or sets the consumer group
         /// </summary>
         public string ConsumerGroup { get; set; }
-        
+
 
         /// <summary>
         /// Gets or sets the Avro schema.
@@ -107,6 +113,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// </summary>
         public string SslKeyPassword { get; set; }
 
+        string IAttributeWithConfigurationString.ConfigurationString => configurationString;
 
         bool IsValidValueType(Type value)
         {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 return Task.FromResult<ITriggerBinding>(null);
             }
 
+            new AttributeEnricher().Enrich(attribute, config, nameResolver);
+
             var consumerConfig = CreateConsumerConfiguration(attribute);
 
             var keyAndValueTypes = SerializationHelper.GetKeyAndValueTypes(attribute.AvroSchema, parameter.ParameterType, typeof(Ignore));

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AttributeEnricherTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AttributeEnricherTest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    public class AttributeEnricherTest
+    {
+        private AttributeEnricher enricher;
+        private IConfigurationRoot config;
+        private DefaultNameResolver nameResolver;
+
+        public AttributeEnricherTest()
+        {
+            this.enricher = new AttributeEnricher();
+            this.config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    {"Protocol", "SaslPlaintext"}
+                }).Build();
+            this.nameResolver = new DefaultNameResolver(config);
+        }
+
+        [Fact]
+        public void When_ConfigurationString_Provided_Populates_Properties()
+        {
+            var attr = new KafkaTriggerAttribute("", "", 
+                @"
+                  Username=""test user"";
+                  AuthenticationMode=Plain;
+                  Protocol=%Protocol%
+                "
+            );
+
+            enricher.Enrich(attr, config, nameResolver);
+
+            Assert.Equal(attr.Username, "test user");
+            Assert.Equal(attr.AuthenticationMode, BrokerAuthenticationMode.Plain);
+            Assert.Equal(attr.Protocol, BrokerProtocol.SaslPlaintext);
+        }
+
+        [Fact]
+        public void When_ConfigurationString_Provided_Populates_NullableProperties()
+        {
+            var attr = new KafkaAttribute("", "", 
+                "MessageTimeoutMs=3000"
+            );
+
+            enricher.Enrich(attr, config, nameResolver);
+
+            Assert.Equal(attr.MessageTimeoutMs, 3000);
+        }
+    }
+}


### PR DESCRIPTION
This is more a POC than a PR. It gives a somewhat weird but also convenient way to handle the issue mention in #161. I've experimented with a few ways, but attributes are very special in what you can do, so this turned out to be an OK solution.

The attribute mentioned in the issue could be written as:

`[KafkaTrigger(@"%Broker%",
              @"%TopicName%",
              @"Protocol=SaslSsl;
                   AuthenticationMode = Plain",  
              SslCaLocation = @"%CaFile%",
              Username = @"%Username%",
              Password = @"%Password%",
              ConsumerGroup = "%ConsumerGroup%" )] KafkaEventData<byte[]>[] events,`

...and that special constructor would only have to be used in these scenarios.