### PR TITLE
Add EnableDeliveryReports to KafkaAttribute

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
@@ -139,5 +139,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// ssl.key.password in librdkafka
         /// </summary>
         public string SslKeyPassword { get; set; }
+        
+        /// <summary>
+        /// Specifies whether to enable notification of delivery reports. Typically you should
+        /// set this parameter to true. Set it to false for "fire and forget" semantics and
+        /// a small boost in performance. default: true importance: low
+        /// </summary>
+        public bool? EnableDeliveryReports { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -112,7 +112,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             {
                 BootstrapServers = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.BrokerList),
                 BatchNumMessages = entity.Attribute.BatchSize,
+                EnableDeliveryReports = entity.Attribute.EnableDeliveryReports,
                 EnableIdempotence = entity.Attribute.EnableIdempotence,
+                MessageMaxBytes = entity.Attribute.MaxMessageBytes,
                 MessageSendMaxRetries = entity.Attribute.MaxRetries,
                 MessageTimeoutMs = entity.Attribute.MessageTimeoutMs,
                 RequestTimeoutMs = entity.Attribute.RequestTimeoutMs,

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaProducerFactoryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaProducerFactoryTest.cs
@@ -304,5 +304,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(sslCa.FullName, config.SslCaLocation);
             Assert.Equal(sslKeyLocation.FullName, config.SslKeyLocation);
         }
+
+        [Fact]
+        public void GetProducerConfig_Copies_Properties_From_Attribute()
+        {
+            var attribute = new KafkaAttribute("brokers:9092", "myTopic")
+            {
+                EnableDeliveryReports = false,
+                BatchSize = 123,
+                EnableIdempotence = true,
+                MaxMessageBytes = 234,
+                MaxRetries = 345,
+                MessageTimeoutMs = 456,
+                RequestTimeoutMs = 567
+            };
+
+            var entity = new KafkaProducerEntity
+            {
+                Attribute = attribute
+            };
+
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var config = factory.GetProducerConfig(entity);
+
+            Assert.Equal(attribute.EnableDeliveryReports, config.EnableDeliveryReports);
+            Assert.Equal(attribute.BatchSize, config.BatchNumMessages);
+            Assert.Equal(attribute.EnableIdempotence, config.EnableIdempotence);
+            Assert.Equal(attribute.MaxMessageBytes, config.MessageMaxBytes);
+            Assert.Equal(attribute.MaxRetries, config.MessageSendMaxRetries);
+            Assert.Equal(attribute.MessageTimeoutMs, config.MessageTimeoutMs);
+            Assert.Equal(attribute.RequestTimeoutMs, config.RequestTimeoutMs);
+            Assert.Equal(attribute.EnableDeliveryReports, config.EnableDeliveryReports);
+        }
     }
 }


### PR DESCRIPTION
Being able to set EnableDeliveryReports is quite valuable, since the collector uses ProduceAsync behind the scenes. In high voulme scenarios, the difference is huge (and the delivery reports are never exposed anyway).

Also, the MaxMessageBytes was never properly copied.