### PR TITLE
Upgrade 1.5.2 and improve debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -284,3 +284,4 @@ local.appsettings.tests.json
 # Mac
 .DS_Store
 
+samples/dotnet/KafkaFunctionSample/

--- a/.gitignore
+++ b/.gitignore
@@ -284,4 +284,5 @@ local.appsettings.tests.json
 # Mac
 .DS_Store
 
-samples/dotnet/KafkaFunctionSample/
+local.settings.json.org
+samples/dotnet/KafkaFunctionSample/Properties/

--- a/README.md
+++ b/README.md
@@ -320,7 +320,10 @@ The settings exposed here are targeted to more advanced users that want to custo
 |FetchMaxBytes|fetch.max.bytes|Trigger
 |AutoCommitIntervalMs|auto.commit.interval.ms|Trigger
 |LibkafkaDebug|debug|Both
-|TopicMetadataRefreshFastIntervalMs|topic.metadata.refresh.interval.ms|Both
+|MetadataMaxAgeMs|metadata.max.age.ms|Both
+|SocketKeepaliveEnable|socket.keepalive.enable|Both
+
+**NOTE:** `MetadataMaxAgeMs` default is `180000` `SocketKeepaliveEnable` default is `true` otherwise, the default value is the same as the [Configuration properties](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md). The reason of the default settings, refer to this [issue](https://github.com/Azure/azure-functions-kafka-extension/issues/187).
 
 If you are missing an configuration setting please create an issue and describe why you need it.
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ The settings exposed here are targeted to more advanced users that want to custo
 |MaxPartitionFetchBytes|max.partition.fetch.bytes|Trigger
 |FetchMaxBytes|fetch.max.bytes|Trigger
 |AutoCommitIntervalMs|auto.commit.interval.ms|Trigger
+|LibkafkaDebug|debug|Trigger
 
 If you are missing an configuration setting please create an issue and describe why you need it.
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,8 @@ The settings exposed here are targeted to more advanced users that want to custo
 |MaxPartitionFetchBytes|max.partition.fetch.bytes|Trigger
 |FetchMaxBytes|fetch.max.bytes|Trigger
 |AutoCommitIntervalMs|auto.commit.interval.ms|Trigger
-|LibkafkaDebug|debug|Trigger
+|LibkafkaDebug|debug|Both
+|TopicMetadataRefreshFastIntervalMs|topic.metadata.refresh.interval.ms|Both
 
 If you are missing an configuration setting please create an issue and describe why you need it.
 

--- a/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
+++ b/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
@@ -5,9 +5,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.4.3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.0" />
   </ItemGroup>
    <ItemGroup>
     <None Update="cacert.pem">

--- a/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
+++ b/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
@@ -5,9 +5,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.2" />
   </ItemGroup>
    <ItemGroup>
     <None Update="cacert.pem">

--- a/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
+++ b/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
@@ -6,9 +6,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.4.3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.0" />
   </ItemGroup>
    <ItemGroup>
     <None Update="cacert.pem">

--- a/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
+++ b/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
@@ -6,9 +6,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.2" />
   </ItemGroup>
    <ItemGroup>
     <None Update="cacert.pem">

--- a/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
+++ b/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
@@ -5,9 +5,9 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.4.3" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
+++ b/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
@@ -5,9 +5,9 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/dotnet/KafkaFunctionSample/SimpleKafkaTriggers.cs
+++ b/samples/dotnet/KafkaFunctionSample/SimpleKafkaTriggers.cs
@@ -45,7 +45,6 @@ namespace KafkaFunctionSample
             return new OkResult();
         }
 
-
         // EventHubs Configuration sample
         //
         //[FunctionName(nameof(SampleConsumer))]

--- a/samples/dotnet/KafkaFunctionSample/SimpleKafkaTriggers.cs
+++ b/samples/dotnet/KafkaFunctionSample/SimpleKafkaTriggers.cs
@@ -7,50 +7,88 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using System;
 using System.IO;
+using System.Text;
 
 namespace KafkaFunctionSample
 {
     public class SimpleKafkaTriggers
     {
-        [FunctionName(nameof(SampleConsumer))]
-        public void SampleConsumer(
-    [KafkaTrigger(
+        [FunctionName(nameof(ConsoleConsumer))]
+        public void ConsoleConsumer(
+        [KafkaTrigger(
             "LocalBroker",
-            "%EHTOPIC%",
+            "stringTopicTenPartitions",
             ConsumerGroup = "$Default",
-            Username = "$ConnectionString",
-            Password = "%EventHubConnectionString%",
-            Protocol = BrokerProtocol.SaslSsl,
-            AuthenticationMode = BrokerAuthenticationMode.Plain)] KafkaEventData<string> kafkaEvent,
-    ILogger logger)
+            AuthenticationMode = BrokerAuthenticationMode.Plain)] KafkaEventData<string>[] kafkaEvents,
+            ILogger logger)
         {
-            logger.LogInformation(kafkaEvent.Value.ToString());
+            foreach(var kafkaEvent in kafkaEvents)
+                logger.LogInformation(kafkaEvent.Value.ToString());
         }
 
-        [FunctionName(nameof(SampleProducer))]
-        public IActionResult SampleProducer(
+        [FunctionName(nameof(ConsoleProducer))]
+        public static IActionResult ConsoleProducer(
         [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
-        [Kafka(
-            "LocalBroker",
-            "%EHTOPIC%",
-            Username = "$ConnectionString",
-            Password = "%EventHubConnectionString%",
-            Protocol = BrokerProtocol.SaslSsl,
-            AuthenticationMode = BrokerAuthenticationMode.Plain)] out KafkaEventData<string>[] kafkaEventData,
-        ILogger logger)
+        [Kafka("LocalBroker", "stringTopicTenPartitions")] out string kafkaEventData,
+        ILogger log)
         {
-            var data = new StreamReader(req.Body).ReadToEnd();
-            kafkaEventData = new[] {
-                    new KafkaEventData<string>()
-                    {
-                        Value = data + ":1:" + DateTime.UtcNow.Ticks,
-                    },
-                    new KafkaEventData<string>()
-                    {
-                        Value = data + ":2:" + DateTime.UtcNow.Ticks,
-                    },
-                };
+            try
+            {
+                var data = new StreamReader(req.Body).ReadToEnd();
+                kafkaEventData = data + ":1:" + DateTime.UtcNow.Ticks;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Are you sure the topic 'stringTopic' exists? To create using Confluent Docker quickstart run this command: 'docker-compose exec broker kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 10 --topic stringTopicTenPartitions'", ex);
+            }
+
             return new OkResult();
         }
+
+
+        // EventHubs Configuration sample
+        //
+        //[FunctionName(nameof(SampleConsumer))]
+        //public void SampleConsumer(
+        //[KafkaTrigger(
+        //    "LocalBroker",
+        //    "%EHTOPIC%",
+        //    ConsumerGroup = "$Default",
+        //    Username = "$ConnectionString",
+        //    Password = "%EventHubConnectionString%",
+        //    Protocol = BrokerProtocol.SaslSsl,
+        //    AuthenticationMode = BrokerAuthenticationMode.Plain)] KafkaEventData<string> kafkaEvent,
+        //ILogger logger)
+        //{
+        //    logger.LogInformation(kafkaEvent.Value.ToString());
+        //}
+
+        // EventHubs Configuration sample
+        //
+        //[FunctionName(nameof(SampleProducer))]
+        //public IActionResult SampleProducer(
+        //[HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
+        //[Kafka(
+        //    "LocalBroker",
+        //    "%EHTOPIC%",
+        //    Username = "$ConnectionString",
+        //    Password = "%EventHubConnectionString%",
+        //    Protocol = BrokerProtocol.SaslSsl,
+        //    AuthenticationMode = BrokerAuthenticationMode.Plain)] out KafkaEventData<string>[] kafkaEventData,
+        //ILogger logger)
+        //{
+        //    var data = new StreamReader(req.Body).ReadToEnd();
+        //    kafkaEventData = new[] {
+        //            new KafkaEventData<string>()
+        //            {
+        //                Value = data + ":1:" + DateTime.UtcNow.Ticks,
+        //            },
+        //            new KafkaEventData<string>()
+        //            {
+        //                Value = data + ":2:" + DateTime.UtcNow.Ticks,
+        //            },
+        //        };
+        //    return new OkResult();
+        //}
     }
 }

--- a/samples/dotnet/KafkaFunctionSample/host.json
+++ b/samples/dotnet/KafkaFunctionSample/host.json
@@ -1,8 +1,20 @@
 {
   "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "default": "Trace",
+      "Host.Triggers.Kafka": "Trace",
+      "Kafka": "Trace",
+      "Host.Results": "Error",
+      "Function": "Trace",
+      "Function.FunctionA": "Warning",
+      "Host.Aggregator": "Trace"
+    }
+  },
   "extensions": {
     "kafka": {
-      "maxBatchSize": 100
-    }    
+      "maxBatchSize": 100,
+      "LibkafkaDebug": "all"
+    }
   }
 }

--- a/samples/dotnet/KafkaFunctionSample/host.json
+++ b/samples/dotnet/KafkaFunctionSample/host.json
@@ -12,9 +12,6 @@
     }
   },
   "extensions": {
-    "kafka": {
-      "maxBatchSize": 100,
-      "LibkafkaDebug": "all"
-    }
+
   }
 }

--- a/samples/dotnet/KafkaFunctionSample/host.json
+++ b/samples/dotnet/KafkaFunctionSample/host.json
@@ -2,9 +2,9 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Trace",
-      "Host.Triggers.Kafka": "Trace",
-      "Kafka": "Trace",
+      "default": "Information",
+      "Host.Triggers.Kafka": "Information",
+      "Kafka": "Information",
       "Host.Results": "Error",
       "Function": "Trace",
       "Function.FunctionA": "Warning",

--- a/samples/dotnet/SampleHost/SampleHost.csproj
+++ b/samples/dotnet/SampleHost/SampleHost.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
   </ItemGroup>

--- a/samples/dotnet/SampleHost/SampleHost.csproj
+++ b/samples/dotnet/SampleHost/SampleHost.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.4.3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
   </ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -142,7 +142,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// 
         /// Librdkafka: debug
         /// </summary>
-        public string LibkafkaDebug { get; set; } = null; 
+        public string LibkafkaDebug { get; set; } = null;
+
+        // <summary>
+        // When a topic loses its leader a new metadata request will be enqueued with this
+        // initial interval, exponentially increasing until the topic metadata has been
+        // refreshed. This is used to recover quickly from transitioning leader brokers.
+        // Use this coinfiguration for EventHubs usage. https://github.com/edenhill/librdkafka/issues/3109
+        // default: 250 importance: low
+        // </summary>
+        public int? TopicMetadataRefreshFastIntervalMs { get; set; }
 
         int subscriberIntervalInSeconds = 1;
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -145,13 +145,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         public string LibkafkaDebug { get; set; } = null;
 
         // <summary>
-        // When a topic loses its leader a new metadata request will be enqueued with this
-        // initial interval, exponentially increasing until the topic metadata has been
-        // refreshed. This is used to recover quickly from transitioning leader brokers.
-        // Use this coinfiguration for EventHubs usage. https://github.com/edenhill/librdkafka/issues/3109
-        // default: 250
+        // Metadata cache max age. 
+        // https://github.com/Azure/azure-functions-kafka-extension/issues/187
+        // default: 180000 
         // </summary>
-        public int? TopicMetadataRefreshFastIntervalMs { get; set; }
+        public int? MetadataMaxAgeMs { get; set; } = 180000;
+
+        // <summary>
+        // Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets 
+        // https://github.com/Azure/azure-functions-kafka-extension/issues/187
+        // default: true
+        // </summary>
+        public bool? SocketKeepaliveEnable { get; set; } = true;
 
         int subscriberIntervalInSeconds = 1;
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// <summary>
         /// Gets or sets the debug option for librdkafka library.
         /// Default = "" (disable)
-        /// 
+        /// A comma-separated list of debug contexts to enable: all,generic,broker,topic,metadata,producer,queue,msg,protocol,cgrp,security,fetch
         /// Librdkafka: debug
         /// </summary>
         public string LibkafkaDebug { get; set; } = null;
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         // initial interval, exponentially increasing until the topic metadata has been
         // refreshed. This is used to recover quickly from transitioning leader brokers.
         // Use this coinfiguration for EventHubs usage. https://github.com/edenhill/librdkafka/issues/3109
-        // default: 250 importance: low
+        // default: 250
         // </summary>
         public int? TopicMetadataRefreshFastIntervalMs { get; set; }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -136,6 +136,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// <value>The auto commit interval ms.</value>
         public int AutoCommitIntervalMs { get; set; } = 200;
 
+        /// <summary>
+        /// Gets or sets the debug option for librdkafka library.
+        /// Default = "" (disable)
+        /// 
+        /// Librdkafka: debug
+        /// </summary>
+        public string LibkafkaDebug { get; set; } = null; 
+
         int subscriberIntervalInSeconds = 1;
         /// <summary>
         /// Defines the minimum frequency in which messages will be executed by function. Only if the message volume is less than <see cref="MaxBatchSize"/> / <see cref="SubscriberIntervalInSeconds"/>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -155,6 +155,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 // Interval in which commits stored in memory will be saved
                 AutoCommitIntervalMs = this.options.AutoCommitIntervalMs,
 
+                // Librdkafka debug options               
+                Debug = this.options.LibkafkaDebug,
+
                 // start from earliest if no checkpoint has been committed
                 AutoOffsetReset = AutoOffsetReset.Earliest,
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -186,7 +186,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 QueuedMaxMessagesKbytes = this.options.QueuedMaxMessagesKbytes,
                 MaxPartitionFetchBytes = this.options.MaxPartitionFetchBytes,
                 FetchMaxBytes = this.options.FetchMaxBytes,
-                TopicMetadataRefreshFastIntervalMs = this.options.TopicMetadataRefreshFastIntervalMs
+                MetadataMaxAgeMs = this.options.MetadataMaxAgeMs,
+                SocketKeepaliveEnable = this.options.SocketKeepaliveEnable
             };
 
             if (string.IsNullOrEmpty(this.listenerConfiguration.EventHubConnectionString))

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -104,6 +104,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 builder.SetValueDeserializer(ValueDeserializer);
             }
 
+            builder.SetLogHandler((_, m) =>
+            {
+                logger.LogInformation($"Libkafka: {m?.Message}");
+            });
+
             return builder.Build();
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -186,6 +186,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 QueuedMaxMessagesKbytes = this.options.QueuedMaxMessagesKbytes,
                 MaxPartitionFetchBytes = this.options.MaxPartitionFetchBytes,
                 FetchMaxBytes = this.options.FetchMaxBytes,
+                TopicMetadataRefreshFastIntervalMs = this.options.TopicMetadataRefreshFastIntervalMs
             };
 
             if (string.IsNullOrEmpty(this.listenerConfiguration.EventHubConnectionString))

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
             builder.SetLogHandler((_, m) =>
             {
-                logger.LogInformation($"Libkafka: {m?.Message}");
+                logger.Log((LogLevel)m.LevelAs(LogLevelType.MicrosoftExtensionsLogging), $"Libkafka: {m?.Message}");
             });
 
             return builder.Build();

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -33,10 +33,10 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.4.3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -33,10 +33,10 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             ILogger logger = this.loggerProvider.CreateLogger("Kafka");
             builder.SetLogHandler((_, m) =>
             {
-                logger.LogInformation($"Libkafka: {m?.Message}");
+                logger.Log((LogLevel)m.LevelAs(LogLevelType.MicrosoftExtensionsLogging), $"Libkafka: {m?.Message}");
             });
 
             return builder.Build();

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             {
                 resolvedSslKeyLocation = entity.Attribute.SslKeyLocation;
             }
-
+            var kafkaOptions = this.config.Get<KafkaOptions>();
             var conf = new ProducerConfig()
             {
                 BootstrapServers = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.BrokerList),
@@ -128,8 +128,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 SslKeyPassword = entity.Attribute.SslKeyPassword,
                 SslCertificateLocation = resolvedSslCertificationLocation,
                 SslCaLocation = resolvedSslCaLocation,
-                Debug = this.config.Get<KafkaOptions>()?.LibkafkaDebug,
-                TopicMetadataRefreshFastIntervalMs = this.config.Get<KafkaOptions>()?.TopicMetadataRefreshFastIntervalMs
+                Debug = kafkaOptions?.LibkafkaDebug,
+                MetadataMaxAgeMs = kafkaOptions?.MetadataMaxAgeMs,
+                SocketKeepaliveEnable = kafkaOptions?.SocketKeepaliveEnable
             };
 
             if (entity.Attribute.AuthenticationMode != BrokerAuthenticationMode.NotSet)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -128,7 +128,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 SslKeyPassword = entity.Attribute.SslKeyPassword,
                 SslCertificateLocation = resolvedSslCertificationLocation,
                 SslCaLocation = resolvedSslCaLocation,
-                Debug = this.config.Get<KafkaOptions>()?.LibkafkaDebug
+                Debug = this.config.Get<KafkaOptions>()?.LibkafkaDebug,
+                TopicMetadataRefreshFastIntervalMs = this.config.Get<KafkaOptions>()?.TopicMetadataRefreshFastIntervalMs
             };
 
             if (entity.Attribute.AuthenticationMode != BrokerAuthenticationMode.NotSet)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -74,6 +74,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         private IProducer<byte[], byte[]> CreateBaseProducer(ProducerConfig producerConfig)
         {
             var builder = new ProducerBuilder<byte[], byte[]>(producerConfig);
+            ILogger logger = this.loggerProvider.CreateLogger("Kafka");
+            builder.SetLogHandler((_, m) =>
+            {
+                logger.LogInformation($"Libkafka: {m?.Message}");
+            });
+
             return builder.Build();
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -121,7 +121,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 SslKeyLocation = resolvedSslKeyLocation,
                 SslKeyPassword = entity.Attribute.SslKeyPassword,
                 SslCertificateLocation = resolvedSslCertificationLocation,
-                SslCaLocation = resolvedSslCaLocation
+                SslCaLocation = resolvedSslCaLocation,
+                Debug = this.config.Get<KafkaOptions>()?.LibkafkaDebug
             };
 
             if (entity.Attribute.AuthenticationMode != BrokerAuthenticationMode.NotSet)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         public MultipleItemFunctionExecutor(ITriggeredFunctionExecutor executor, IConsumer<TKey, TValue> consumer, int channelCapacity, int channelFullRetryIntervalInMs, ICommitStrategy<TKey, TValue> commitStrategy, ILogger logger) 
             : base(executor, consumer, channelCapacity, channelFullRetryIntervalInMs, commitStrategy, logger)
         {
+            logger.LogInformation($"FunctionExecutor Loaded: {nameof(MultipleItemFunctionExecutor<TKey, TValue>)}");
         }
 
         protected override async Task ReaderAsync(ChannelReader<IKafkaEventData[]> reader, CancellationToken cancellationToken, ILogger logger)
@@ -39,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                             TriggerValue = triggerInput,
                         };
 
-                        var functionResult = await this.ExecuteFunctionAsync(triggerData, cancellationToken);
+                         var functionResult = await this.ExecuteFunctionAsync(triggerData, cancellationToken);
 
                         var offsetsToCommit = new Dictionary<int, TopicPartitionOffset>();
                         for (var i=itemsToExecute.Length - 1; i >= 0; i--)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                             TriggerValue = triggerInput,
                         };
 
-                         var functionResult = await this.ExecuteFunctionAsync(triggerData, cancellationToken);
+                        var functionResult = await this.ExecuteFunctionAsync(triggerData, cancellationToken);
 
                         var offsetsToCommit = new Dictionary<int, TopicPartitionOffset>();
                         for (var i=itemsToExecute.Length - 1; i >= 0; i--)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/SingleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/SingleItemFunctionExecutor.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         public SingleItemFunctionExecutor(ITriggeredFunctionExecutor executor, IConsumer<TKey, TValue> consumer, int channelCapacity, int channelFullRetryIntervalInMs, ICommitStrategy<TKey, TValue> commitStrategy, ILogger logger)
             : base(executor, consumer, channelCapacity, channelFullRetryIntervalInMs, commitStrategy, logger)
         {
+            logger.LogInformation($"FunctionExecutor Loaded: {nameof(MultipleItemFunctionExecutor<TKey, TValue>)}");
         }
 
         protected override async Task ReaderAsync(ChannelReader<IKafkaEventData[]> reader, CancellationToken cancellationToken, ILogger logger)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/SingleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/SingleItemFunctionExecutor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         public SingleItemFunctionExecutor(ITriggeredFunctionExecutor executor, IConsumer<TKey, TValue> consumer, int channelCapacity, int channelFullRetryIntervalInMs, ICommitStrategy<TKey, TValue> commitStrategy, ILogger logger)
             : base(executor, consumer, channelCapacity, channelFullRetryIntervalInMs, commitStrategy, logger)
         {
-            logger.LogInformation($"FunctionExecutor Loaded: {nameof(MultipleItemFunctionExecutor<TKey, TValue>)}");
+            logger.LogInformation($"FunctionExecutor Loaded: {nameof(SingleItemFunctionExecutor<TKey, TValue>)}");
         }
 
         protected override async Task ReaderAsync(ChannelReader<IKafkaEventData[]> reader, CancellationToken cancellationToken, ILogger logger)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -27,10 +27,10 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="1.5.0" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.4.3" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.4.3" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
+    <PackageReference Include="Confluent.Kafka" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             await target.StartAsync(default);
 
-            Assert.Equal(10, target.ConsumerConfig.Count());
+            Assert.Equal(12, target.ConsumerConfig.Count());
             Assert.Equal("testBroker", target.ConsumerConfig.BootstrapServers);
             Assert.Equal("group1", target.ConsumerConfig.GroupId);
             Assert.Equal("password1", target.ConsumerConfig.SslKeyPassword);
@@ -352,6 +352,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(kafkaOptions.AutoCommitIntervalMs, target.ConsumerConfig.AutoCommitIntervalMs);
             Assert.Equal(true, target.ConsumerConfig.EnableAutoCommit);
             Assert.Equal(false, target.ConsumerConfig.EnableAutoOffsetStore);
+            Assert.Equal(180000, target.ConsumerConfig.MetadataMaxAgeMs);
+            Assert.Equal(true, target.ConsumerConfig.SocketKeepaliveEnable);
             Assert.Equal(AutoOffsetReset.Earliest, target.ConsumerConfig.AutoOffsetReset);
 
             await target.StopAsync(default);
@@ -390,7 +392,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             await target.StartAsync(default);
 
-            Assert.Equal(10, target.ConsumerConfig.Count());
+            Assert.Equal(12, target.ConsumerConfig.Count());
             Assert.Equal("testBroker", target.ConsumerConfig.BootstrapServers);
             Assert.Equal("group1", target.ConsumerConfig.GroupId);
             Assert.Equal(kafkaOptions.AutoCommitIntervalMs, target.ConsumerConfig.AutoCommitIntervalMs);


### PR DESCRIPTION
This PR includes

* Upgrade Confluent.Kafka 1.5.2
* Adding Following Libkafka properties with default values. 
* Add Log to identify if users use SingleFunctionExecutor or MultipleFunctionExecutor
* Redirect Libkafka Log to the ILogger

|Setting|librdkafka property|default|Trigger or Output|
|-|-|-|-|
|LibkafkaDebug|debug|null|Both
|MetadataMaxAgeMs|metadata.max.age.ms|180000|Both
|SocketKeepaliveEnable|socket.keepalive.enable|true|Both

## Upgrade Confluent Kafka for avoiding limitation for Azure about the log-lived TCP Connection

The reason of the default settings, refer to this [issue](https://github.com/Azure/azure-functions-kafka-extension/issues/187)

## Add Log to detect which FunctionExecutor do they use?

For the log of FunctionExecutor, I'd like to know if a user uses Single or Multiple Function Executor for diagnosing an issue.
If there is a better place, please let me know.

## Redirect the Log of Libkafka native library

Currently, the Libkafka message is showed up standard output, that means there is no way to fetch it from Application Insights or other logging system. 

Debug option enables librdkafka logging. https://github.com/edenhill/librdkafka

# Fix
https://github.com/Azure/azure-functions-kafka-extension/issues/185
https://github.com/Azure/azure-functions-kafka-extension/issues/187
