### PR TITLE
Add ClientId configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ The settings exposed here are targeted to more advanced users that want to custo
 |LibkafkaDebug|debug|Both
 |MetadataMaxAgeMs|metadata.max.age.ms|Both
 |SocketKeepaliveEnable|socket.keepalive.enable|Both
+|ClientId|client.id|Both
 
 **NOTE:** `MetadataMaxAgeMs` default is `180000` `SocketKeepaliveEnable` default is `true` otherwise, the default value is the same as the [Configuration properties](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md). The reason of the default settings, refer to this [issue](https://github.com/Azure/azure-functions-kafka-extension/issues/187).
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
@@ -139,5 +139,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// ssl.key.password in librdkafka
         /// </summary>
         public string SslKeyPassword { get; set; }
+
+        /// <summary>
+        /// Client identifier.
+        /// Default: the hostname of the client machine
+        /// client.id in librdkafka
+        /// </summary>
+        public string ClientId { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Net;
 using System.Reflection;
 using System.Text;
 using Avro.Generic;
@@ -130,7 +131,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 SslCaLocation = resolvedSslCaLocation,
                 Debug = kafkaOptions?.LibkafkaDebug,
                 MetadataMaxAgeMs = kafkaOptions?.MetadataMaxAgeMs,
-                SocketKeepaliveEnable = kafkaOptions?.SocketKeepaliveEnable
+                SocketKeepaliveEnable = kafkaOptions?.SocketKeepaliveEnable,
+                ClientId = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.ClientId) ?? Dns.GetHostName()
             };
 
             if (entity.Attribute.AuthenticationMode != BrokerAuthenticationMode.NotSet)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaListenerConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaListenerConfiguration.cs
@@ -94,6 +94,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// </summary>
         public string SslKeyPassword { get; set; }
 
+        /// <summary>
+        /// Client identifier.
+        /// Default: the hostname of the client machine
+        /// client.id in librdkafka
+        /// </summary>
+        public string ClientId { get; set; }
+
         internal void ApplyToConfig(ClientConfig conf)
         {
             if (this.SaslMechanism.HasValue)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttribute.cs
@@ -107,6 +107,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// </summary>
         public string SslKeyPassword { get; set; }
 
+        /// <summary>
+        /// Client identifier.
+        /// Default: the hostname of the client machine
+        /// client.id in librdkafka
+        /// </summary>
+        public string ClientId { get; set; }
 
         bool IsValidValueType(Type value)
         {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 ConsumerGroup = this.config.ResolveSecureSetting(nameResolver, attribute.ConsumerGroup),
                 Topic = this.config.ResolveSecureSetting(nameResolver, attribute.Topic),
                 EventHubConnectionString = this.config.ResolveSecureSetting(nameResolver, attribute.EventHubConnectionString),
+                ClientId = this.config.ResolveSecureSetting(nameResolver, attribute.ClientId)
             };
 
             if (attribute.AuthenticationMode != BrokerAuthenticationMode.NotSet || 


### PR DESCRIPTION
Adds a ClientId parameter to the KafkaTrigger. This is good thing to have, e.g for collecting metrics. In our Confluent dashboard we get this warning:

"Unable to compute throughput.
There are multiple consumers
reading from this topic that do not
have unique client IDs"

This implementation sets Dns.GetHostName() as the default value. It could be regarded as a breaking change. An option could be to wrap the INameResolver in a "SuperSpecialNameResolver", which checks the output from the wrapped resolver for special values. If you want to use Dns.GetHostName() as your client ID, you could specify e.g. "%{dns.gethostname}%" as the attribute value. 