### PR TITLE
Upgrade KafkaLibrary for pre release

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>3.2.1$(VersionSuffix)</Version>
+    <Version>3.3.1-PRE1$(VersionSuffix)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>

--- a/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
+++ b/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
@@ -5,9 +5,9 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.6.0-PRE4" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.6.0-PRE4" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/dotnet/SampleHost/SampleHost.csproj
+++ b/samples/dotnet/SampleHost/SampleHost.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.2" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.6.0-PRE4" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.6.0-PRE4" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.6.0-PRE4" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
   </ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -33,10 +33,10 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.2" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.2" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.6.0-PRE4" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.6.0-PRE4" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.6.0-PRE4" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.6.0-PRE4" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -27,10 +27,10 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.5.2" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.5.2" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.5.2" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.5.2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.6.0-PRE4" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="1.6.0-PRE4" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.6.0-PRE4" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.6.0-PRE4" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="1.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
I'd like to pre-release to fix the `GroupCoordinator: *.*.*.*:9092: 1 request(s) timed out: disconnect` for this update solve the issue. 
That issue Could happens Azure Backed infractructure e.g. EventHubs,  HDInsights based Kafka.

I reproduce the issue with 3.2.1 with EventHubs with Kafka API. 
With this version, the issue is resolved. 

For the official release, I'll release with Confluent.Kafka library with 1.6.0. However, until then, mitigate the issue by using this version. 

