### PR TITLE
Add consumergourp to event data

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/IKafkaEventData.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/IKafkaEventData.cs
@@ -14,5 +14,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         string Topic { get; }
         DateTime Timestamp { get; }
         IKafkaEventDataHeaders Headers { get; }
+        string ConsumerGroup { get; }    
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/KafkaEventData.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/KafkaEventData.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         object IKafkaEventData.Key => this.Key;
 
+        public string ConsumerGroup { get; internal set; }
+
         public KafkaEventData()
         {
             this.Headers = new KafkaEventDataHeaders(false);
@@ -31,8 +33,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             this.Key = key;
             this.Value = value;
         }
-
-        public KafkaEventData(ConsumeResult<TKey, TValue> consumeResult)
+        public KafkaEventData(ConsumeResult<TKey, TValue> consumeResult) : this(consumeResult, null)
+        { 
+        }
+        public KafkaEventData(ConsumeResult<TKey, TValue> consumeResult, string consumerGroup)
         {
             this.Key = consumeResult.Key;
             this.Value = consumeResult.Value;
@@ -40,6 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             this.Partition = consumeResult.Partition;
             this.Timestamp = consumeResult.Message.Timestamp.UtcDateTime;
             this.Topic = consumeResult.Topic;
+            this.ConsumerGroup = consumerGroup;
             if (consumeResult.Headers?.Count > 0)
             {
                 this.Headers = new KafkaEventDataHeaders(consumeResult.Message.Headers);
@@ -63,7 +68,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         object IKafkaEventData.Key => null;
 
-        public IKafkaEventDataHeaders Headers { get; private set; } 
+        public IKafkaEventDataHeaders Headers { get; private set; }
+
+        public string ConsumerGroup { get; internal set; }
 
         public KafkaEventData()
         {
@@ -80,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             this.Headers = headers;
         }
 
-        internal static KafkaEventData<TValue> CreateFrom<TKey>(ConsumeResult<TKey, TValue> consumeResult)
+        internal static KafkaEventData<TValue> CreateFrom<TKey>(ConsumeResult<TKey, TValue> consumeResult, string consumerGroup = null)
         {
             KafkaEventDataHeaders headers;
             if (consumeResult.Headers?.Count > 0)
@@ -98,7 +105,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 Offset = consumeResult.Offset,
                 Partition = consumeResult.Partition,
                 Timestamp = consumeResult.Timestamp.UtcDateTime,
-                Topic = consumeResult.Topic
+                Topic = consumeResult.Topic,
+                ConsumerGroup = consumerGroup
             };
 
             return result;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -286,8 +286,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                                 else
                                 {
                                     var kafkaEventData = this.requiresKey ? 
-                                        (IKafkaEventData)new KafkaEventData<TKey, TValue>(consumeResult) : 
-                                        KafkaEventData<TValue>.CreateFrom(consumeResult);
+                                        (IKafkaEventData)new KafkaEventData<TKey, TValue>(consumeResult, this.consumerGroup) : 
+                                        KafkaEventData<TValue>.CreateFrom(consumeResult, this.consumerGroup);
 
                                     // add message to executor
                                     // if executor pending items is full, flush it

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerBindingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerBindingStrategy.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             AddBindingContractMember(contract, nameof(KafkaEventData<TKey, TValue>.Topic), typeof(string), isSingleDispatch);
             AddBindingContractMember(contract, nameof(KafkaEventData<TKey, TValue>.Timestamp), typeof(DateTime), isSingleDispatch);
             AddBindingContractMember(contract, nameof(KafkaEventData<TKey, TValue>.Offset), typeof(long), isSingleDispatch);
-
+            AddBindingContractMember(contract, nameof(KafkaEventData<TKey, TValue>.ConsumerGroup), typeof(string), isSingleDispatch);
             return contract;
         }
 
@@ -89,12 +89,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             var timestamps = new DateTime[length];
             var topics = new string[length];
             var keys = new object[length];
+            var consumerGroups = new string[length];
 
             bindingData.Add("PartitionArray", partitions);
             bindingData.Add("OffsetArray", offsets);
             bindingData.Add("TimestampArray", timestamps);
             bindingData.Add("TopicArray", topics);
             bindingData.Add("KeyArray", keys);
+            bindingData.Add("ConsumerGroupArray", consumerGroups);
 
             for (int i = 0; i < events.Length; i++)
             {
@@ -103,6 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 timestamps[i] = events[i].Timestamp;
                 keys[i] = events[i].Key;
                 topics[i] = events[i].Topic;
+                consumerGroups[i] = events[i].ConsumerGroup;
             }
         }
 
@@ -113,6 +116,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             bindingData.Add(nameof(IKafkaEventData.Topic), eventData.Topic);
             bindingData.Add(nameof(IKafkaEventData.Timestamp), eventData.Timestamp);
             bindingData.Add(nameof(IKafkaEventData.Offset), eventData.Offset);
+            bindingData.Add(nameof(IKafkaEventData.ConsumerGroup), eventData.ConsumerGroup);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerBindingStrategyTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerBindingStrategyTest.cs
@@ -15,12 +15,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var strategy = new KafkaTriggerBindingStrategy<string, string>();
             var contract = strategy.GetBindingContract();
 
-            Assert.Equal(5, contract.Count);
+            Assert.Equal(6, contract.Count);
             Assert.Equal(typeof(object), contract["Key"]);
             Assert.Equal(typeof(int), contract["Partition"]);
             Assert.Equal(typeof(string), contract["Topic"]);
             Assert.Equal(typeof(DateTime), contract["Timestamp"]);
             Assert.Equal(typeof(long), contract["Offset"]);
+            Assert.Equal(typeof(string), contract["ConsumerGroup"]);
         }
 
         [Fact]
@@ -29,12 +30,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var strategy = new KafkaTriggerBindingStrategy<string, string>();
             var contract = strategy.GetBindingContract(true);
 
-            Assert.Equal(5, contract.Count);
+            Assert.Equal(6, contract.Count);
             Assert.Equal(typeof(object), contract["Key"]);
             Assert.Equal(typeof(int), contract["Partition"]);
             Assert.Equal(typeof(string), contract["Topic"]);
             Assert.Equal(typeof(DateTime), contract["Timestamp"]);
             Assert.Equal(typeof(long), contract["Offset"]);
+            Assert.Equal(typeof(string), contract["ConsumerGroup"]);
         }
 
         [Fact]
@@ -48,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 Timestamp = new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc),
                 Topic = "myTopic",
                 Value = "Nothing",
+                ConsumerGroup = "myConsumerGroup"
             };
 
             var strategy = new KafkaTriggerBindingStrategy<string, string>();
@@ -57,6 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(2, binding["Partition"]);
             Assert.Equal(new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc), binding["Timestamp"]);
             Assert.Equal("myTopic", binding["Topic"]);
+            Assert.Equal("myConsumerGroup", binding["ConsumerGroup"]);
 
             // lower case too
             Assert.Equal("1", binding["key"]);
@@ -64,6 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(2, binding["partition"]);
             Assert.Equal(new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc), binding["timestamp"]);
             Assert.Equal("myTopic", binding["topic"]);
+            Assert.Equal("myConsumerGroup", binding["consumergroup"]);
         }
 
         [Fact]
@@ -79,6 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                     Timestamp = new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc),
                     Topic = "myTopic",
                     Value = "Nothing1",
+                    ConsumerGroup = "myConsumerGroup1"
                 },
                 new KafkaEventData<string, string>()
                 {
@@ -88,6 +94,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                     Timestamp = new DateTime(2019, 1, 10, 9, 21, 1, DateTimeKind.Utc),
                     Topic = "myTopic",
                     Value = "Nothing2",
+                    ConsumerGroup = "myConsumerGroup2"
                 },
             });
 
@@ -98,6 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(new[] { 2, 2 }, binding["PartitionArray"]);
             Assert.Equal(new[] { new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc), new DateTime(2019, 1, 10, 9, 21, 1, DateTimeKind.Utc) }, binding["TimestampArray"]);
             Assert.Equal(new[] { "myTopic", "myTopic" }, binding["TopicArray"]);
+            Assert.Equal(new[] { "myConsumerGroup1", "myConsumerGroup2" }, binding["ConsumerGroupArray"]);
 
             // lower case too
             Assert.Equal(new[] { "1", "2" }, binding["keyArray"]);
@@ -105,6 +113,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(new[] { 2, 2 }, binding["partitionArray"]);
             Assert.Equal(new[] { new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc), new DateTime(2019, 1, 10, 9, 21, 1, DateTimeKind.Utc) }, binding["timestampArray"]);
             Assert.Equal(new[] { "myTopic", "myTopic" }, binding["topicArray"]);
+            Assert.Equal(new[] { "myConsumerGroup1", "myConsumerGroup2" }, binding["consumerGroupArray"]);
         }
     }
 }


### PR DESCRIPTION
It's useful e.g in a scenario where multiple functions are in the same function app, and there's something (like in our case, a retry handler) that should be able to handle events from them all.

Either way, it's basically on the same level as having "Topic" on the event class.