### PR TITLE
Injectable topic scaler factory

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaExtensionConfigProvider.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         private readonly INameResolver nameResolver;
         private readonly IWebJobsExtensionConfiguration<KafkaExtensionConfigProvider> configuration;
         private readonly IKafkaProducerFactory kafkaProducerFactory;
+        private readonly IKafkaTopicScalerFactory kafkaTopicScalerFactory;
         private readonly ILogger logger;
 
         public KafkaExtensionConfigProvider(
@@ -38,7 +39,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             IConverterManager converterManager,
             INameResolver nameResolver,
             IWebJobsExtensionConfiguration<KafkaExtensionConfigProvider> configuration,
-            IKafkaProducerFactory kafkaProducerFactory)
+            IKafkaProducerFactory kafkaProducerFactory, 
+            IKafkaTopicScalerFactory kafkaTopicScalerFactory
+            )
         {
             this.config = config;
             this.options = options;
@@ -47,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             this.nameResolver = nameResolver;
             this.configuration = configuration;
             this.kafkaProducerFactory = kafkaProducerFactory;
+            this.kafkaTopicScalerFactory = kafkaTopicScalerFactory;
             this.logger = loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Kafka"));
         }
 
@@ -55,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             configuration.ConfigurationSection.Bind(options);
 
             // register our trigger binding provider
-            var triggerBindingProvider = new KafkaTriggerAttributeBindingProvider(config, options, converterManager, nameResolver, loggerFactory);
+            var triggerBindingProvider = new KafkaTriggerAttributeBindingProvider(config, options, converterManager, nameResolver, kafkaTopicScalerFactory, loggerFactory);
             context.AddBindingRule<KafkaTriggerAttribute>()
                 .BindToTrigger(triggerBindingProvider);
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaWebJobsBuilderExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaWebJobsBuilderExtensions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             });
 
             builder.Services.AddSingleton<IKafkaProducerFactory, KafkaProducerFactory>();
+            builder.Services.AddSingleton<IKafkaTopicScalerFactory, DefaultKafkaTopicScalerFactory>();
 
             return builder;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/DefaultKafkaTopicScalerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/DefaultKafkaTopicScalerFactory.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    public class DefaultKafkaTopicScalerFactory : IKafkaTopicScalerFactory
+    {
+        public KafkaTopicScaler<TKey, TValue> CreateKafkaTopicScaler<TKey, TValue>(string topic, string consumerGroup, string functionId, IConsumer<TKey, TValue> consumer, AdminClientConfig adminClientConfig, ILogger logger)
+        {
+            return new KafkaTopicScaler<TKey, TValue>(topic, consumerGroup, functionId, consumer, adminClientConfig, logger);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/IKafkaTopicScalerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/IKafkaTopicScalerFactory.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    public interface IKafkaTopicScalerFactory
+    {
+        KafkaTopicScaler<TKey, TValue> CreateKafkaTopicScaler<TKey, TValue>(string topic, string consumerGroup, string functionId, IConsumer<TKey, TValue> consumer, AdminClientConfig adminClientConfig, ILogger logger);
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         private readonly KafkaListenerConfiguration listenerConfiguration;
         // Indicates if the consumer requires the Kafka element key
         private readonly bool requiresKey;
+        private readonly IKafkaTopicScalerFactory kafkaTopicScalerFactory;
         private readonly ILogger logger;
         private FunctionExecutorBase<TKey, TValue> functionExecutor;
         private Lazy<IConsumer<TKey, TValue>> consumer;
@@ -62,10 +63,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             KafkaListenerConfiguration kafkaListenerConfiguration,
             bool requiresKey,
             IDeserializer<TValue> valueDeserializer,
+            IKafkaTopicScalerFactory kafkaTopicScalerFactory,
             ILogger logger,
             string functionId)
         {
             this.ValueDeserializer = valueDeserializer;
+            this.kafkaTopicScalerFactory = kafkaTopicScalerFactory;
             this.executor = executor;
             this.singleDispatch = singleDispatch;
             this.options = options;
@@ -114,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         private KafkaTopicScaler<TKey, TValue> CreateTopicScaler()
         {
-            return new KafkaTopicScaler<TKey, TValue>(this.listenerConfiguration.Topic, this.consumerGroup, this.functionId, this.consumer.Value, new AdminClientConfig(GetConsumerConfiguration()), this.logger);
+            return kafkaTopicScalerFactory.CreateKafkaTopicScaler(this.listenerConfiguration.Topic, this.consumerGroup, this.functionId, this.consumer.Value, new AdminClientConfig(GetConsumerConfiguration()), this.logger);
         }
 
         public void Cancel()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaTopicScaler.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaTopicScaler.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return GetScaleStatusCore(context.WorkerCount, context.Metrics?.OfType<KafkaTriggerMetrics>().ToArray());
         }
 
-        public ScaleStatus GetScaleStatus(ScaleStatusContext<KafkaTriggerMetrics> context)
+        public virtual ScaleStatus GetScaleStatus(ScaleStatusContext<KafkaTriggerMetrics> context)
         {
             return GetScaleStatusCore(context.WorkerCount, context.Metrics?.ToArray());
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         private readonly IConfiguration config;
         private readonly IConverterManager converterManager;
         private readonly INameResolver nameResolver;
+        private readonly IKafkaTopicScalerFactory kafkaTopicScalerFactory;
         private readonly IOptions<KafkaOptions> options;
         private readonly ILogger logger;
 
@@ -29,11 +30,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             IOptions<KafkaOptions> options,
             IConverterManager converterManager,
             INameResolver nameResolver,
+            IKafkaTopicScalerFactory kafkaTopicScalerFactory,
             ILoggerFactory loggerFactory)
         {
             this.config = config;
             this.converterManager = converterManager;
             this.nameResolver = nameResolver;
+            this.kafkaTopicScalerFactory = kafkaTopicScalerFactory;
             this.options = options;
             this.logger = loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Kafka"));
         }   
@@ -75,6 +78,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                     listenerConfiguration,
                     requiresKey,
                     valueDeserializer,
+                    kafkaTopicScalerFactory,
                     this.logger,
                     factoryContext.Descriptor.Id);
                 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Helpers/KafkaListenerForTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Helpers/KafkaListenerForTest.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 kafkaListenerConfiguration,
                 requiresKey,
                 valueDeserializer,
+                new DefaultKafkaTopicScalerFactory(),
                 logger,
                 functionId)
         {

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
@@ -115,7 +115,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 config,
                 Options.Create(new KafkaOptions()),
                 new KafkaEventDataConvertManager(NullLogger.Instance),
-                new DefaultNameResolver(config),                
+                new DefaultNameResolver(config),
+                new DefaultKafkaTopicScalerFactory(),
                 NullLoggerFactory.Instance);
             
             var parameterInfo = new TriggerBindingProviderContext(this.GetParameterInfo(functionName), default);
@@ -152,6 +153,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 Options.Create(new KafkaOptions()),
                 new KafkaEventDataConvertManager(NullLogger.Instance),
                 new DefaultNameResolver(config),
+                new DefaultKafkaTopicScalerFactory(),
                 NullLoggerFactory.Instance);
 
             var parameterInfo = new TriggerBindingProviderContext(this.GetParameterInfo(functionName), default);
@@ -189,6 +191,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 Options.Create(new KafkaOptions()),
                 new KafkaEventDataConvertManager(NullLogger.Instance),
                 new DefaultNameResolver(config),
+                new DefaultKafkaTopicScalerFactory(),
                 NullLoggerFactory.Instance);
 
             var parameterInfo = new TriggerBindingProviderContext(this.GetParameterInfo(functionName), default);
@@ -226,6 +229,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 Options.Create(new KafkaOptions()),
                 new KafkaEventDataConvertManager(NullLogger.Instance),
                 new DefaultNameResolver(config),
+                new DefaultKafkaTopicScalerFactory(),
                 NullLoggerFactory.Instance);
 
             var parameterInfo = new TriggerBindingProviderContext(this.GetParameterInfo(functionName), default);
@@ -263,6 +267,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 Options.Create(new KafkaOptions()),
                 new KafkaEventDataConvertManager(NullLogger.Instance),
                 new DefaultNameResolver(config),
+                new DefaultKafkaTopicScalerFactory(),
                 NullLoggerFactory.Instance);
 
             var parameterInfo = new TriggerBindingProviderContext(this.GetParameterInfo(functionName), default);
@@ -312,6 +317,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 Options.Create(new KafkaOptions()),
                 new KafkaEventDataConvertManager(NullLogger.Instance),
                 new DefaultNameResolver(config),
+                new DefaultKafkaTopicScalerFactory(),
                 NullLoggerFactory.Instance);
 
             var parameterInfo = new TriggerBindingProviderContext(this.GetParameterInfo(functionName), default);


### PR DESCRIPTION
Allows injecting custom scaling logic. Now, in fairness, the factory could have been an IScaleMonitorFactory.

Use case:

Custom handling of scaling, based on metrics, such as ensuring (at least trying) a minimal or maximal worker count (for an entire function app)