### PR TITLE
Change the log level since it could happens when we use extension bundles

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                         }
                     }
 
-                    logger.LogInformation("Librdkafka initialization: did not attempt to load librdkafka because the desired file(s) does not exist: '{searchedPaths}'", string.Join(",", possibleLibrdKafkaLibraryPaths));
+                    logger.LogWarning("Librdkafka initialization: did not attempt to load librdkafka because the desired file(s) does not exist: '{searchedPaths}' You can ignore this warning when you use extension bundle.", string.Join(",", possibleLibrdKafkaLibraryPaths));
                 }
                 else
                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                         }
                     }
 
-                    logger.LogError("Librdkafka initialization: did not attempt to load librdkafka because the desired file(s) does not exist: '{searchedPaths}'", string.Join(",", possibleLibrdKafkaLibraryPaths));
+                    logger.LogInformation("Librdkafka initialization: did not attempt to load librdkafka because the desired file(s) does not exist: '{searchedPaths}'", string.Join(",", possibleLibrdKafkaLibraryPaths));
                 }
                 else
                 {


### PR DESCRIPTION
When we use extension bundle, it could possible that the native library is not exists under `wwwroot` on a windows worker. 
I noticed that kusto query returns error on that part for the extension bundle use case. 

So that I made it as warning and add context for the message. 


