### PR TITLE
Added Examples Section in Trigger and Output

### DIFF
--- a/docs/public-documentation/Output.md
+++ b/docs/public-documentation/Output.md
@@ -126,7 +126,7 @@ Username and password should reference a Azure function configuration variable a
 
 # Java
 
-The following Java function uses the @KafkaOutput annotation from the Azure function Java Client library to describe the configuration for a Kafka topic output binding. The function sends a message to the Kafka topic.
+The following Java function uses the @KafkaOutput annotation from the Azure function Java Client library (https://mvnrepository.com/artifact/com.microsoft.azure.functions/azure-functions-java-library) to describe the configuration for a Kafka topic output binding. The function sends a message to the Kafka topic.
 
 ```java
 @FunctionName("KafkaOutput")

--- a/docs/public-documentation/Output.md
+++ b/docs/public-documentation/Output.md
@@ -222,7 +222,7 @@ Here&#39;s the binding data in the _function.json_ file:
 }
 ```
 
-Here's JavaScript code:
+Here is JavaScript code:
 
 ```js
 module.exports = async function (context, req) {
@@ -239,7 +239,7 @@ module.exports = async function (context, req) {
 ### Powershell
 The following example shows a Kafka output binding in a function.json file and a Powershell function that uses the binding. The function reads in the message from an HTTP trigger and outputs it to the Kafka topic.
 
-Here&#39;s the binding data in the _function.json_ file:
+Here is the binding data in the _function.json_ file:
 ```json
 {
   "bindings": [
@@ -300,7 +300,7 @@ Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
 
 The following example shows a Kafka output binding in a function.json file and a Python function that uses the binding. The function reads in the message from an HTTP trigger and outputs it to the Kafka topic.
 
-Here&#39;s the binding data in the _function.json_ file:
+Here is the binding data in the _function.json_ file:
 
 ```json
 {
@@ -334,6 +334,7 @@ Here&#39;s the binding data in the _function.json_ file:
   ]
 }
 ```
+Here is the Python script code:
 
 In _init_.py:
 ```py
@@ -346,6 +347,63 @@ def main(req: func.HttpRequest, outputMessage: func.Out[str]) -> func.HttpRespon
     input_msg = req.params.get('message')
     outputMessage.set(input_msg)
     return 'OK'
+```
+
+### Typescript
+
+The following example shows a Kafka output binding in a function.json file and a Typescript function that uses the binding. The function reads in the message from an HTTP trigger and outputs it to the Kafka topic.
+
+Here is the binding data in the _function.json_ file:
+
+```json
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get"      
+       ]
+    },
+    {
+      "type": "kafka",
+      "name": "outputKafkaMessage",
+      "topic": "topic",
+      "brokerList": "%BrokerList%",
+      "username": "%ConfluentCloudUserName%",
+      "password": "%ConfluentCloudPassword%",
+      "protocol": "SASLSSL",
+      "authenticationMode": "PLAIN",
+      "direction": "out"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/KafkaOutput/index.js"
+}
+```
+
+Here's the typescript script code:
+
+```ts
+import { AzureFunction, Context, HttpRequest } from "@azure/functions"
+
+const kafkaOutput: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
+    const message = req.query.message;
+    const responseMessage = 'Ok'
+    context.bindings.outputKafkaMessage = message;
+    context.res = {
+        body: responseMessage
+    };
+
+};
+
+export default kafkaOutput;
 ```
 
 

--- a/docs/public-documentation/Trigger.md
+++ b/docs/public-documentation/Trigger.md
@@ -147,7 +147,8 @@ Write-Output "Powershell Kafka trigger function called for message $kafkaEvent.V
 
 ## Python
 
-The following example demonstrates how to read a Kafka queue message via a trigger.
+The following example shows a Kafka trigger binding in a function.json file and a Python function that uses the binding. The function reads and logs a Kafka message.
+
 
 A Kafka binding is defined in function.json where type is set to KafkaTrigger.
 
@@ -169,7 +170,7 @@ A Kafka binding is defined in function.json where type is set to KafkaTrigger.
     ]
 }
 ```
-
+Here's the Python script code:
 ```py
 import logging
 from azure.functions import KafkaEvent

--- a/docs/public-documentation/Trigger.md
+++ b/docs/public-documentation/Trigger.md
@@ -56,7 +56,7 @@ public static void Run(
 
 ## Java
 
-The following example shows an Kafka trigger binding which logs the message body of the Kafka trigger.
+The following Java function uses the @KafkaTrigger annotation from the Java Client library (https://mvnrepository.com/artifact/com.microsoft.azure.functions/azure-functions-java-library) to describe the configuration for a KafkaTrigger trigger. The function grabs the message placed on the topic and adds it to the logs.
 
 ```java
 @FunctionName("KafkaTrigger")
@@ -79,7 +79,7 @@ public void runSingle(
 
 ## Javascript
 
-The following example shows a Kafka trigger binding in a function.json file and a JavaScript function that uses the binding. The function reads and logs a Kafka  message.
+The following example shows a Kafka trigger binding in a function.json file and a [JavaScript](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node) function that uses the binding. The function reads and logs a Kafka  message.
 
 Here's the binding data in the function.json file:
 ```json
@@ -178,6 +178,82 @@ from azure.functions import KafkaEvent
 def main(kevent : KafkaEvent):
     logging.info("Python Kafka trigger function called for message " + kevent.metadata["Value"])
 ```
+
+### Typescript
+
+The following example shows a Kafka trigger binding in a function.json file and a Typescript function that uses the binding. The function reads and logs a Kafka message.
+
+Here's the binding data in the function.json file:
+
+```json
+{
+    "bindings": [
+      {
+        "type": "kafkaTrigger",
+        "direction": "in",
+        "name": "event",
+        "topic": "topic",
+        "brokerList": "%BrokerList%",
+        "username": "%ConfluentCloudUserName%",
+        "password": "%ConfluentCloudPassword%",
+        "consumerGroup" : "functions",
+        "protocol": "saslSsl",
+        "authenticationMode": "plain",
+        "dataType": "string"
+      }
+    ],
+    "scriptFile": "../dist/KafkaTrigger/index.js"
+  }
+```
+Here's the Typescript script code:
+```ts
+import { AzureFunction, Context } from "@azure/functions"
+
+// This is to describe the metadata of a Kafka event
+class KafkaEvent {
+    Offset : number;
+    Partition : number;
+    Topic : string;
+    Timestamp : string;
+    Value : string;
+    
+    constructor(metadata:any) {
+        this.Offset = metadata.Offset;
+        this.Partition = metadata.Partition;
+        this.Topic = metadata.Topic;
+        this.Timestamp = metadata.Timestamp;
+        this.Value = metadata.Value;
+    }
+
+    public getValue<T>() : T {
+        return JSON.parse(this.Value).payload;
+    }
+}
+
+// This is a sample interface that describes the actual data in your event.
+interface EventData {
+    registertime : number;
+    userid : string;
+    regionid: string;
+    gender: string;
+}
+
+const kafkaTrigger: AzureFunction = async function (context: Context, event_str: string): Promise<void> {
+
+    let event_obj = new KafkaEvent(eval(event_str));
+
+    context.log("Event Offset: " + event_obj.Offset);
+    context.log("Event Partition: " + event_obj.Partition);
+    context.log("Event Topic: " + event_obj.Topic);
+    context.log("Event Timestamp: " + event_obj.Timestamp);
+    context.log("Event Value (as string): " + event_obj.Value);
+};
+
+export default kafkaTrigger;
+```
+
+
+
 # C# Attributes
 
 |Setting|Description|

--- a/docs/public-documentation/Trigger.md
+++ b/docs/public-documentation/Trigger.md
@@ -9,6 +9,174 @@ For information on setup and configuration details, see the overview
 
 # Examples
 
+## C#
+
+The C# function can be created using one of the following C# modes:
+
+- [In-process class library](https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library): compiled C# function that runs in the same process as the Functions runtime.
+- [Isolated process class library](https://docs.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide): compiled C# function that runs in a process isolated from the runtime. Isolated process is required to support C# functions running on .NET 5.0.
+
+The following example shows a C# function that reads and logs the Kafka message as a KafkaEvent:
+
+### InProcess
+The following example shows a C# function that reads and logs the Kafka message as a KafkaEvent:
+
+```csharp
+[FunctionName("KafkaTrigger")]
+public static void Run(
+    [KafkaTrigger("BrokerList",
+                    "topic",
+                    Username = "ConfluentCloudUserName",
+                    Password = "ConfluentCloudPassword",
+                    Protocol = BrokerProtocol.SaslSsl,
+                    AuthenticationMode = BrokerAuthenticationMode.Plain,
+                    ConsumerGroup = "$Default")] KafkaEventData<string> kevent, ILogger log)
+{            
+    log.LogInformation($"C# Kafka trigger function processed a message: {kevent.Value}");
+}
+```
+
+
+### IsolatedProcess
+```csharp
+[Function("KafkaTrigger")]
+public static void Run(
+    [KafkaTrigger("BrokerList",
+                    "topic",
+                    Username = "ConfluentCloudUserName",
+                    Password = "ConfluentCloudPassword",
+                    Protocol = BrokerProtocol.SaslSsl,
+                    AuthenticationMode = BrokerAuthenticationMode.Plain,
+                    ConsumerGroup = "$Default")] string eventData, FunctionContext context)
+{
+    var logger = context.GetLogger("KafkaFunction");
+    logger.LogInformation($"C# Kafka trigger function processed a message: {JObject.Parse(eventData)["Value"]}");
+}
+```
+
+## Java
+
+The following example shows an Kafka trigger binding which logs the message body of the Kafka trigger.
+
+```java
+@FunctionName("KafkaTrigger")
+public void runSingle(
+        @KafkaTrigger(
+            name = "KafkaTrigger",
+            topic = "topic",  
+            brokerList="%BrokerList%",
+            consumerGroup="$Default", 
+            username = "%ConfluentCloudUsername%", 
+            password = "ConfluentCloudPassword",
+            authenticationMode = BrokerAuthenticationMode.PLAIN,
+            protocol = BrokerProtocol.SASLSSL,
+            dataType = "string") String kafkaEventData,
+        final ExecutionContext context) 
+    {
+        context.getLogger().info(kafkaEventData);
+    }
+```
+
+## Javascript
+
+The following example shows a Kafka trigger binding in a function.json file and a JavaScript function that uses the binding. The function reads and logs a Kafka  message.
+
+Here's the binding data in the function.json file:
+```json
+{
+    "bindings": [
+        {
+            "type": "kafkaTrigger",
+            "name": "event",
+            "direction": "in",
+            "topic": "topic",
+            "brokerList": "%BrokerList%",
+            "username": "%ConfluentCloudUserName%",
+            "password": "%ConfluentCloudPassword%",
+            "protocol": "saslSsl",
+            "authenticationMode": "plain",
+            "consumerGroup" : "$Default",
+            "dataType": "string"
+        }
+    ]
+}
+```
+Here's the JavaScript script code:
+```js
+module.exports = async function (context, event) {
+    context.log.info(`JavaScript Kafka trigger function called for message ${event.Value}`);
+};
+```
+
+## Powershell
+The following example demonstrates how to read a Kafka message passed to a function via a trigger.
+
+Kafka trigger is defined in function.json file where type is set to kafkaTrigger.
+
+```json
+{
+    "bindings": [
+      {
+            "type": "kafkaTrigger",
+            "name": "kafkaEvent",
+            "direction": "in",
+            "protocol" : "SASLSSL",
+            "password" : "%ConfluentCloudPassword%",
+            "dataType" : "string",
+            "topic" : "topic",
+            "authenticationMode" : "PLAIN",
+            "consumerGroup" : "$Default",
+            "username" : "%ConfluentCloudUserName%",
+            "brokerList" : "%BrokerList%",
+            "sslCaLocation": "confluent_cloud_cacert.pem"
+        }
+    ]
+}
+```
+
+The code in the Run.ps1 file declares a parameter as $kafkaEvent, which allows you to read the kafka event message in your function.
+
+```ps
+using namespace System.Net
+
+param($kafkaEvent, $TriggerMetadata)
+
+Write-Output "Powershell Kafka trigger function called for message $kafkaEvent.Value"
+```
+
+
+## Python
+
+The following example demonstrates how to read a Kafka queue message via a trigger.
+
+A Kafka binding is defined in function.json where type is set to KafkaTrigger.
+
+```json
+{
+      "scriptFile": "main.py",
+      "bindings": [
+        {
+          "type": "kafkaTrigger",
+          "name": "kevent",
+          "topic": "topic",
+          "brokerList": "%BrokerList%",
+          "username": "%ConfluentCloudUserName%",
+          "password": "%ConfluentCloudPassword%",
+          "consumerGroup" : "functions",
+          "protocol": "saslSsl",
+          "authenticationMode": "plain"
+        }
+    ]
+}
+```
+
+```py
+import logging
+from azure.functions import KafkaEvent
+
+def main(kevent : KafkaEvent):
+    logging.info("Python Kafka trigger function called for message " + kevent.metadata["Value"])
+```
 # C# Attributes
 
 |Setting|Description|


### PR DESCRIPTION
Added examples section for Kafka trigger and output binding public documentation. This includes adding examples for processing single as well as batch events.
Added code snippets of all supported runtimes for azure functions.