### PR TITLE
POC: Init only properties on KafkaEventData

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/IsExternalInit.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/IsExternalInit.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+#if NETSTANDARD2_0
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+#endif

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/KafkaEventData.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/KafkaEventData.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 {
     public class KafkaEventData<TKey, TValue> : IKafkaEventData
     {
-        public TKey Key { get; set; }
-        public long Offset { get; set; }
-        public int Partition { get; set; }
-        public string Topic { get; set; }
+        public TKey Key { get; init; }
+        public long Offset { get; init; }
+        public int Partition { get; init; }
+        public string Topic { get; init; }
         public IKafkaEventDataHeaders Headers { get; }
-        public DateTime Timestamp { get; set; }
-        public TValue Value { get; set; }
+        public DateTime Timestamp { get; init; }
+        public TValue Value { get; init; }
 
         object IKafkaEventData.Value => this.Value;
 
@@ -53,11 +53,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
     public class KafkaEventData<TValue> : IKafkaEventData
     {
-        public long Offset { get; set; }
-        public int Partition { get; set; }
-        public string Topic { get; set; }
-        public DateTime Timestamp { get; set; }
-        public TValue Value { get; set; }
+        public long Offset { get; init; }
+        public int Partition { get; init; }
+        public string Topic { get; init; }
+        public DateTime Timestamp { get; init; }
+        public TValue Value { get; init; }
 
         object IKafkaEventData.Value => this.Value;
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Version>$(Version)</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.Kafka</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.Kafka</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.Kafka</PackageId>
@@ -12,13 +12,13 @@
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
-    <Copyright>&#169; Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/azure-functions-kafka-extension</RepositoryUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerAsyncCollector.cs
@@ -80,9 +80,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         private KafkaEventData<string> BuildKafkaEventData(JObject dataObj)
         {
-            KafkaEventData<string> messageToSend = new KafkaEventData<string>((string)dataObj["Value"]);
-            messageToSend.Timestamp = (DateTime)dataObj["Timestamp"];
-            messageToSend.Partition = (int)dataObj["Partition"];
+            KafkaEventData<string> messageToSend = new KafkaEventData<string>((string)dataObj["Value"])
+            {
+                Timestamp = (DateTime)dataObj["Timestamp"],
+                Partition = (int)dataObj["Partition"]
+            };
             JArray headerList = (JArray)dataObj["Headers"];
             foreach (JObject header in headerList) {
                 messageToSend.Headers.Add((string)header["Key"], Encoding.UTF8.GetBytes((string)header["Value"]));

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
@@ -621,6 +621,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 .Select(x => {
                     var eventData = new KafkaEventData<string>
                     {
+                        Topic = Constants.StringTopicWithTenPartitionsName,
                         Value = x.ToString()
                     };
 
@@ -650,6 +651,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var input = Enumerable.Range(0, 10)
                 .Select(x => new KafkaEventData<string>
                 {
+                    Topic = Constants.StringTopicWithTenPartitionsName,
                     Value = x.ToString()
                 });
 
@@ -672,10 +674,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         private async Task<List<KafkaEventData<string>>> ProduceAndConsumeAsync(IEnumerable<KafkaEventData<string>> events) 
         {
             var eventList = events.ToList();
-            foreach (var kafkaEvent in eventList)
-            {
-                kafkaEvent.Topic = Constants.StringTopicWithTenPartitionsName;
-            }
             var eventCount = eventList.Count;
             var output = new ConcurrentBag<KafkaEventData<string>>();
             using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>), typeof(KafkaTriggerForProduceAndConsume<KafkaEventData<string>>) },


### PR DESCRIPTION
The settable properties on KafkaEventData are important for the flow of events, especially the offset. They should not be subject to tampering. IMO, different types should be used for sending and receiving. 