### PR TITLE
Exposing AutoOffsetReset property in KafkaOptions

### DIFF
--- a/Microsoft.Azure.WebJobs.Extensions.Kafka.sln
+++ b/Microsoft.Azure.WebJobs.Extensions.Kafka.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28701.123
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32616.157
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleConsumer", "samples\dotnet\ConsoleConsumer\ConsoleConsumer.csproj", "{2AFC1B40-7E2E-40D3-A53B-AA9CDE71C93D}"
 EndProject
@@ -24,7 +24,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleHost", "samples\dotne
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests", "test\Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests\Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj", "{EDADAFD3-445B-4CE0-834C-F2D19DFD26CB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests", "test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests.csproj", "{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests", "test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests.csproj", "{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "kafkaFunc", "kafkaFunc\kafkaFunc.csproj", "{51EA8834-D064-46C3-A6F8-C062EA7B1126}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -67,6 +69,10 @@ Global
 		{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51EA8834-D064-46C3-A6F8-C062EA7B1126}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51EA8834-D064-46C3-A6F8-C062EA7B1126}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51EA8834-D064-46C3-A6F8-C062EA7B1126}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51EA8834-D064-46C3-A6F8-C062EA7B1126}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -81,6 +87,7 @@ Global
 		{90727327-BBCC-4D30-8BFC-D1E71093B489} = {7F1BF36A-84F8-4944-8B9F-1B350F3581E4}
 		{EDADAFD3-445B-4CE0-834C-F2D19DFD26CB} = {3BB99C76-1457-4106-BAC5-78A4BE558D27}
 		{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096} = {3BB99C76-1457-4106-BAC5-78A4BE558D27}
+		{51EA8834-D064-46C3-A6F8-C062EA7B1126} = {7F1BF36A-84F8-4944-8B9F-1B350F3581E4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5F624115-1576-40AC-B51A-F565023FD5C1}

--- a/Microsoft.Azure.WebJobs.Extensions.Kafka.sln
+++ b/Microsoft.Azure.WebJobs.Extensions.Kafka.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.2.32616.157
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28701.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleConsumer", "samples\dotnet\ConsoleConsumer\ConsoleConsumer.csproj", "{2AFC1B40-7E2E-40D3-A53B-AA9CDE71C93D}"
 EndProject
@@ -24,9 +24,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleHost", "samples\dotne
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests", "test\Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests\Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj", "{EDADAFD3-445B-4CE0-834C-F2D19DFD26CB}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests", "test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests.csproj", "{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "kafkaFunc", "kafkaFunc\kafkaFunc.csproj", "{51EA8834-D064-46C3-A6F8-C062EA7B1126}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests", "test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests.csproj", "{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,10 +67,6 @@ Global
 		{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096}.Release|Any CPU.Build.0 = Release|Any CPU
-		{51EA8834-D064-46C3-A6F8-C062EA7B1126}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{51EA8834-D064-46C3-A6F8-C062EA7B1126}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{51EA8834-D064-46C3-A6F8-C062EA7B1126}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{51EA8834-D064-46C3-A6F8-C062EA7B1126}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -87,7 +81,6 @@ Global
 		{90727327-BBCC-4D30-8BFC-D1E71093B489} = {7F1BF36A-84F8-4944-8B9F-1B350F3581E4}
 		{EDADAFD3-445B-4CE0-834C-F2D19DFD26CB} = {3BB99C76-1457-4106-BAC5-78A4BE558D27}
 		{F0D4F8D5-1F16-4A11-AAA7-73DEBB34A096} = {3BB99C76-1457-4106-BAC5-78A4BE558D27}
-		{51EA8834-D064-46C3-A6F8-C062EA7B1126} = {7F1BF36A-84F8-4944-8B9F-1B350F3581E4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5F624115-1576-40AC-B51A-F565023FD5C1}

--- a/README.md
+++ b/README.md
@@ -319,11 +319,13 @@ The settings exposed here are targeted to more advanced users that want to custo
 |MaxPartitionFetchBytes|max.partition.fetch.bytes|Trigger
 |FetchMaxBytes|fetch.max.bytes|Trigger
 |AutoCommitIntervalMs|auto.commit.interval.ms|Trigger
+|AutoOffsetReset|auto.offset.reset|Trigger
 |LibkafkaDebug|debug|Both
 |MetadataMaxAgeMs|metadata.max.age.ms|Both
 |SocketKeepaliveEnable|socket.keepalive.enable|Both
 
 **NOTE:** `MetadataMaxAgeMs` default is `180000` `SocketKeepaliveEnable` default is `true` otherwise, the default value is the same as the [Configuration properties](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md). The reason of the default settings, refer to this [issue](https://github.com/Azure/azure-functions-kafka-extension/issues/187).
+**NOTE:** `AutoOffsetReset` default is Earliest. Allowed Values are `Earliest` and `Latest`.
 
 If you are missing an configuration setting please create an issue and describe why you need it.
 

--- a/docs/public-documentation/Trigger.md
+++ b/docs/public-documentation/Trigger.md
@@ -691,6 +691,7 @@ The settings exposed here are to customize how librdkafka works. [Librdkafka Doc
 |MaxPartitionFetchBytes|max.partition.fetch.bytes|
 |FetchMaxBytes|fetch.max.bytes|
 |AutoCommitIntervalMs|auto.commit.interval.ms|
+|AutoOffsetReset|auto.offset.reset|
 |LibkafkaDebug|debug|
 |MetadataMaxAgeMs|metadata.max.age.ms|
 |SocketKeepaliveEnable|socket.keepalive.enable|

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -136,6 +136,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// <value>The auto commit interval ms.</value>
         public int AutoCommitIntervalMs { get; set; } = 200;
 
+        AutoOffsetReset autoOffsetReset = AutoOffsetReset.Earliest;
+
         /// <summary>
         /// Ges or sets the AutoOffsetReset option for librdkafka library.
         /// default: Earliest
@@ -143,8 +145,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// Librdkafka: auto.commit.offset
         /// </summary>
         public AutoOffsetReset AutoOffsetReset {
-            get => this.AutoOffsetReset;
-            set => this.AutoOffsetReset = AutoOffsetReset.Latest.Equals(value) ? AutoOffsetReset.Latest : AutoOffsetReset.Earliest; 
+            get => this.autoOffsetReset;
+            set => this.autoOffsetReset = AutoOffsetReset.Latest.Equals(value) ? AutoOffsetReset.Latest : AutoOffsetReset.Earliest; 
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -137,6 +137,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         public int AutoCommitIntervalMs { get; set; } = 200;
 
         /// <summary>
+        /// Ges or sets the AutoOffsetReset option for librdkafka library.
+        /// default: Earliest
+        /// Allowed Values: Latest, Earliest
+        /// Librdkafka: auto.commit.offset
+        /// </summary>
+        public AutoOffsetReset AutoOffsetReset {
+            get => this.AutoOffsetReset;
+            set => this.AutoOffsetReset = AutoOffsetReset.Latest.Equals(value) ? AutoOffsetReset.Latest : AutoOffsetReset.Earliest; 
+        }
+
+        /// <summary>
         /// Gets or sets the debug option for librdkafka library.
         /// Default = "" (disable)
         /// A comma-separated list of debug contexts to enable: all,generic,broker,topic,metadata,producer,queue,msg,protocol,cgrp,security,fetch

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 Debug = this.options.LibkafkaDebug,
 
                 // start from earliest if no checkpoint has been committed
-                AutoOffsetReset = AutoOffsetReset.Earliest,
+                AutoOffsetReset = this.options.AutoOffsetReset,
 
                 // Secure communication/authentication
                 SaslMechanism = this.listenerConfiguration.SaslMechanism,

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
@@ -350,6 +350,62 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("path/to/key", target.ConsumerConfig.SslKeyLocation);
             Assert.Equal("path/to/cacert", target.ConsumerConfig.SslCaLocation);
             Assert.Equal(kafkaOptions.AutoCommitIntervalMs, target.ConsumerConfig.AutoCommitIntervalMs);
+            Assert.Equal(AutoOffsetReset.Earliest, target.ConsumerConfig.AutoOffsetReset);
+            Assert.Equal(true, target.ConsumerConfig.EnableAutoCommit);
+            Assert.Equal(false, target.ConsumerConfig.EnableAutoOffsetStore);
+            Assert.Equal(180000, target.ConsumerConfig.MetadataMaxAgeMs);
+            Assert.Equal(true, target.ConsumerConfig.SocketKeepaliveEnable);
+            Assert.Equal(AutoOffsetReset.Earliest, target.ConsumerConfig.AutoOffsetReset);
+
+            await target.StopAsync(default);
+        }
+
+        [Fact]
+        public async Task When_Options_With_AutoOffsetReset_Latest_Are_Set_Should_Be_Set_In_Consumer_Config()
+        {
+            var executor = new Mock<ITriggeredFunctionExecutor>();
+            var consumer = new Mock<IConsumer<Ignore, string>>();
+
+            var listenerConfig = new KafkaListenerConfiguration()
+            {
+                BrokerList = "testBroker",
+                Topic = "topic",
+                ConsumerGroup = "group1",
+                SslKeyPassword = "password1",
+                SslCertificateLocation = "path/to/cert",
+                SslKeyLocation = "path/to/key",
+                SslCaLocation = "path/to/cacert"
+            };
+
+            var kafkaOptions = new KafkaOptions()
+            {
+                AutoOffsetReset = AutoOffsetReset.Latest
+            };
+
+            var target = new KafkaListenerForTest<Ignore, string>(
+                executor.Object,
+                true,
+                kafkaOptions,
+                listenerConfig,
+                requiresKey: true,
+                valueDeserializer: null,
+                NullLogger.Instance,
+                functionId: "testId"
+                );
+
+            target.SetConsumer(consumer.Object);
+
+            await target.StartAsync(default);
+
+            Assert.Equal(12, target.ConsumerConfig.Count());
+            Assert.Equal("testBroker", target.ConsumerConfig.BootstrapServers);
+            Assert.Equal("group1", target.ConsumerConfig.GroupId);
+            Assert.Equal("password1", target.ConsumerConfig.SslKeyPassword);
+            Assert.Equal("path/to/cert", target.ConsumerConfig.SslCertificateLocation);
+            Assert.Equal("path/to/key", target.ConsumerConfig.SslKeyLocation);
+            Assert.Equal("path/to/cacert", target.ConsumerConfig.SslCaLocation);
+            Assert.Equal(kafkaOptions.AutoCommitIntervalMs, target.ConsumerConfig.AutoCommitIntervalMs);
+            Assert.Equal(AutoOffsetReset.Latest, target.ConsumerConfig.AutoOffsetReset);
             Assert.Equal(true, target.ConsumerConfig.EnableAutoCommit);
             Assert.Equal(false, target.ConsumerConfig.EnableAutoOffsetStore);
             Assert.Equal(180000, target.ConsumerConfig.MetadataMaxAgeMs);

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
@@ -355,7 +355,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(false, target.ConsumerConfig.EnableAutoOffsetStore);
             Assert.Equal(180000, target.ConsumerConfig.MetadataMaxAgeMs);
             Assert.Equal(true, target.ConsumerConfig.SocketKeepaliveEnable);
-            Assert.Equal(AutoOffsetReset.Earliest, target.ConsumerConfig.AutoOffsetReset);
 
             await target.StopAsync(default);
         }
@@ -410,7 +409,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(false, target.ConsumerConfig.EnableAutoOffsetStore);
             Assert.Equal(180000, target.ConsumerConfig.MetadataMaxAgeMs);
             Assert.Equal(true, target.ConsumerConfig.SocketKeepaliveEnable);
-            Assert.Equal(AutoOffsetReset.Earliest, target.ConsumerConfig.AutoOffsetReset);
 
             await target.StopAsync(default);
         }


### PR DESCRIPTION
- Exposes librdkafka "auto.offset.reset" property as AutoOffsetReset in KafkaOptions. This also allows the property to be set using extension settings in host.json for functions.
- Allows only two values for the property - Latest and Earliest. Default: Earliest.
- Unit test for default and AutoOffsetReset = Latest case. 
- Updated Documentation.
Based on #216 