### PR TITLE
Fixing issues related to Application Insights Logging

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -24,22 +24,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
     {
         private readonly IConfiguration config;
         private readonly INameResolver nameResolver;
-        private readonly ILoggerProvider loggerProvider;
+        private readonly ILoggerFactory loggerFactory;
         private readonly ConcurrentDictionary<string, IProducer<byte[], byte[]>> baseProducers = new ConcurrentDictionary<string, IProducer<byte[], byte[]>>();
 
         public KafkaProducerFactory(
             IConfiguration config,
             INameResolver nameResolver,
-            ILoggerProvider loggerProvider)
+            ILoggerFactory loggerFactory)
         {
             this.config = config;
             this.nameResolver = nameResolver;
-            this.loggerProvider = loggerProvider;
+            this.loggerFactory = loggerFactory;
         }
 
         public IKafkaProducer Create(KafkaProducerEntity entity)
         {
-            AzureFunctionsFileHelper.InitializeLibrdKafka(this.loggerProvider.CreateLogger(LogCategories.CreateTriggerCategory("Kafka")));
+            AzureFunctionsFileHelper.InitializeLibrdKafka(this.loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Kafka")));
 
             // Goal is to create as less producers as possible
             // We can group producers based on following criterias
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         private IProducer<byte[], byte[]> CreateBaseProducer(ProducerConfig producerConfig)
         {
             var builder = new ProducerBuilder<byte[], byte[]>(producerConfig);
-            ILogger logger = this.loggerProvider.CreateLogger("Kafka");
+            ILogger logger = this.loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Kafka"));
             builder.SetLogHandler((_, m) =>
             {
                 logger.Log((LogLevel)m.LevelAs(LogLevelType.MicrosoftExtensionsLogging), $"Libkafka: {m?.Message}");
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 typeof(KafkaProducer<,>).MakeGenericType(keyType, valueType),
                 producerBaseHandle,
                 valueSerializer,
-                loggerProvider.CreateLogger(LogCategories.CreateTriggerCategory("Kafka")));
+                loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Kafka")));
         }
 
         public ProducerConfig GetProducerConfig(KafkaProducerEntity entity)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         public IKafkaProducer Create(KafkaProducerEntity entity)
         {
-            AzureFunctionsFileHelper.InitializeLibrdKafka(this.loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Kafka")));
+            AzureFunctionsFileHelper.InitializeLibrdKafka(this.loggerFactory.CreateLogger(typeof(AzureFunctionsFileHelper)));
 
             // Goal is to create as less producers as possible
             // We can group producers based on following criterias
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         private IProducer<byte[], byte[]> CreateBaseProducer(ProducerConfig producerConfig)
         {
             var builder = new ProducerBuilder<byte[], byte[]>(producerConfig);
-            ILogger logger = this.loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Kafka"));
+            ILogger logger = this.loggerFactory.CreateLogger("Kafka");
             builder.SetLogHandler((_, m) =>
             {
                 logger.Log((LogLevel)m.LevelAs(LogLevelType.MicrosoftExtensionsLogging), $"Libkafka: {m?.Message}");
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 typeof(KafkaProducer<,>).MakeGenericType(keyType, valueType),
                 producerBaseHandle,
                 valueSerializer,
-                loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Kafka")));
+                loggerFactory.CreateLogger(typeof(KafkaProducer<,>)));
         }
 
         public ProducerConfig GetProducerConfig(KafkaProducerEntity entity)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaProducerFactoryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaProducerFactoryTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 Attribute = attribute,
             };
 
-            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var producer = factory.Create(entity);
 
             Assert.NotNull(producer);
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 ValueType = typeof(string),
             };
 
-            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var producer = factory.Create(entity);
 
             Assert.NotNull(producer);
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 AvroSchema = attribute.AvroSchema,
             };
 
-            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var producer = factory.Create(entity);
 
             Assert.NotNull(producer);
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 AvroSchema = MyAvroRecord.SchemaText,
             };
 
-            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var producer = factory.Create(entity);
 
             Assert.NotNull(producer);
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 ValueType = typeof(ProtoUser),
             };
 
-            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var producer = factory.Create(entity);
 
             Assert.NotNull(producer);
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 ValueType = typeof(ProtoUser),
             };
 
-            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var config = factory.GetProducerConfig(entity);
             Assert.Single(config);
             Assert.Equal("brokers:9092", config.BootstrapServers);
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 ValueType = typeof(ProtoUser),
             };
 
-            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var config = factory.GetProducerConfig(entity);
             Assert.Equal(5, config.Count());
             Assert.Equal("brokers:9092", config.BootstrapServers);
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 ValueType = typeof(ProtoUser),
             };
 
-            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var config = factory.GetProducerConfig(entity);
             Assert.Equal(6, config.Count());
             Assert.Equal("brokers:9092", config.BootstrapServers);
@@ -263,7 +263,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 ValueType = typeof(ProtoUser)
             };
 
-            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var config = factory.GetProducerConfig(entity);
             Assert.Equal(sslCertificate.FullName, config.SslCertificateLocation);
             Assert.Equal(sslCa.FullName, config.SslCaLocation);
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 ValueType = typeof(ProtoUser)
             };
 
-            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerProvider.Instance);
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var config = factory.GetProducerConfig(entity);
             Assert.Equal(sslCertificate.FullName, config.SslCertificateLocation);
             Assert.Equal(sslCa.FullName, config.SslCaLocation);


### PR DESCRIPTION
For Kafka output binding function, the extension logs were not being collected in application insights. In this PR, we have fixed this issue. 