### PR TITLE
adding the sample for accessing key in java function with avro

### DIFF
--- a/samples/java/eventhub/src/main/java/com/contoso/kafka/avro/generic/KafkaTriggerAvroGeneric.java
+++ b/samples/java/eventhub/src/main/java/com/contoso/kafka/avro/generic/KafkaTriggerAvroGeneric.java
@@ -52,7 +52,7 @@ public class KafkaTriggerAvroGeneric {
     }
 
     /**
-     * BindingName attribute will be useful retrieving the metadate passed like Key
+     * BindingName attribute will be useful retrieving the metadata passed like Key
      * in the case of Avro Generic Binding
      */
     @FunctionName("KafkaAvroGenericTriggerKey")

--- a/samples/java/eventhub/src/main/java/com/contoso/kafka/avro/generic/KafkaTriggerAvroGeneric.java
+++ b/samples/java/eventhub/src/main/java/com/contoso/kafka/avro/generic/KafkaTriggerAvroGeneric.java
@@ -4,6 +4,7 @@ import com.contoso.kafka.entity.Payment;
 import com.microsoft.azure.functions.BrokerAuthenticationMode;
 import com.microsoft.azure.functions.BrokerProtocol;
 import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.annotation.BindingName;
 import com.microsoft.azure.functions.annotation.Cardinality;
 import com.microsoft.azure.functions.annotation.FunctionName;
 import com.microsoft.azure.functions.annotation.KafkaTrigger;
@@ -48,5 +49,27 @@ public class KafkaTriggerAvroGeneric {
         for (String paymentStr: paymentArr) {
             context.getLogger().info(paymentStr);
         }
+    }
+
+    /**
+     * BindingName attribute will be useful retrieving the metadate passed like Key
+     * in the case of Avro Generic Binding
+     */
+    @FunctionName("KafkaAvroGenericTriggerKey")
+    public void runAvroKey(
+            @KafkaTrigger(
+                    name = "kafkaAvroGenericKeySingle",
+                    topic = "topic",
+                    brokerList="%BrokerList%",
+                    consumerGroup="$Default",
+                    username = "$ConnectionString",
+                    password = "EventHubConnectionString",
+                    avroSchema = schema,
+                    authenticationMode = BrokerAuthenticationMode.PLAIN,
+                    protocol = BrokerProtocol.SASLSSL) Payment payment,
+            @BindingName("Key") String key,
+            final ExecutionContext context) {
+        context.getLogger().info("Key :: "+ key);
+        context.getLogger().info(payment.toString());
     }
 }


### PR DESCRIPTION
Kafka extension currently supports the key in trigger and output bindings.
For the edge case when Generic Avro for java it's passed as metadata and there is no direct access.
For showcasing how can key value can be accessed the samples function is created

- Doesn't requires any unit test case
- Doesn't require any E2E test case