### PR TITLE
Bug Fix for fail to load certificate location for KafkaTrigger

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -100,10 +100,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             {
                 consumerConfig.SaslPassword = this.config.ResolveSecureSetting(nameResolver, attribute.Password);
                 consumerConfig.SaslUsername = this.config.ResolveSecureSetting(nameResolver, attribute.Username);
-                consumerConfig.SslKeyLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslKeyLocation);
                 consumerConfig.SslKeyPassword = this.config.ResolveSecureSetting(nameResolver, attribute.SslKeyPassword);
-                consumerConfig.SslCertificateLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslCertificateLocation);
-                consumerConfig.SslCaLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslCaLocation);
+
+                var sslKeyLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslKeyLocation);
+                if (!AzureFunctionsFileHelper.TryGetValidFilePath(sslKeyLocation, out var resolvedSslKeyLocation))
+                {
+                    resolvedSslKeyLocation = sslKeyLocation;
+                }
+
+                var sslCertificateLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslCertificateLocation);
+                if (!AzureFunctionsFileHelper.TryGetValidFilePath(sslCertificateLocation, out var resolvedSslCertificationLocation))
+                {
+                    resolvedSslCertificationLocation = sslCertificateLocation;
+                }
+
+                var sslCaLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslCaLocation);
+                if (!AzureFunctionsFileHelper.TryGetValidFilePath(sslCaLocation, out var resolvedSslCaLocation))
+                {
+                    resolvedSslCaLocation = sslCaLocation;
+                }
+                consumerConfig.SslKeyLocation = resolvedSslKeyLocation;
+                consumerConfig.SslCertificateLocation = resolvedSslCertificationLocation;
+                consumerConfig.SslCaLocation = resolvedSslCaLocation;
 
                 if (attribute.AuthenticationMode != BrokerAuthenticationMode.NotSet)
                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -100,28 +100,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             {
                 consumerConfig.SaslPassword = this.config.ResolveSecureSetting(nameResolver, attribute.Password);
                 consumerConfig.SaslUsername = this.config.ResolveSecureSetting(nameResolver, attribute.Username);
+                consumerConfig.SslKeyLocation = GetValidFilePath(attribute.SslKeyLocation);
                 consumerConfig.SslKeyPassword = this.config.ResolveSecureSetting(nameResolver, attribute.SslKeyPassword);
-
-                var sslKeyLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslKeyLocation);
-                if (!AzureFunctionsFileHelper.TryGetValidFilePath(sslKeyLocation, out var resolvedSslKeyLocation))
-                {
-                    resolvedSslKeyLocation = sslKeyLocation;
-                }
-
-                var sslCertificateLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslCertificateLocation);
-                if (!AzureFunctionsFileHelper.TryGetValidFilePath(sslCertificateLocation, out var resolvedSslCertificationLocation))
-                {
-                    resolvedSslCertificationLocation = sslCertificateLocation;
-                }
-
-                var sslCaLocation = this.config.ResolveSecureSetting(nameResolver, attribute.SslCaLocation);
-                if (!AzureFunctionsFileHelper.TryGetValidFilePath(sslCaLocation, out var resolvedSslCaLocation))
-                {
-                    resolvedSslCaLocation = sslCaLocation;
-                }
-                consumerConfig.SslKeyLocation = resolvedSslKeyLocation;
-                consumerConfig.SslCertificateLocation = resolvedSslCertificationLocation;
-                consumerConfig.SslCaLocation = resolvedSslCaLocation;
+                consumerConfig.SslCertificateLocation = GetValidFilePath(attribute.SslCertificateLocation);
+                consumerConfig.SslCaLocation = GetValidFilePath(attribute.SslCaLocation);
 
                 if (attribute.AuthenticationMode != BrokerAuthenticationMode.NotSet)
                 {
@@ -135,6 +117,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             }
 
             return consumerConfig;
+        }
+
+        private string GetValidFilePath(string location)
+        {
+            var resolvedLocation = this.config.ResolveSecureSetting(nameResolver, location);
+            if (!AzureFunctionsFileHelper.TryGetValidFilePath(resolvedLocation, out var validPath))
+            {
+                throw new Exception($"{location} is not a valid file location");
+            }
+            return validPath;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return BindingFactory.GetTriggerBinding(new KafkaTriggerBindingStrategy<TKey, TValue>(), parameter, new KafkaEventDataConvertManager(this.converterManager, this.logger), listenerCreator);
         }
 
-        private KafkaListenerConfiguration CreateConsumerConfiguration(KafkaTriggerAttribute attribute)
+        public KafkaListenerConfiguration CreateConsumerConfiguration(KafkaTriggerAttribute attribute)
         {
             var consumerConfig = new KafkaListenerConfiguration()
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return BindingFactory.GetTriggerBinding(new KafkaTriggerBindingStrategy<TKey, TValue>(), parameter, new KafkaEventDataConvertManager(this.converterManager, this.logger), listenerCreator);
         }
 
-        public KafkaListenerConfiguration CreateConsumerConfiguration(KafkaTriggerAttribute attribute)
+        private KafkaListenerConfiguration CreateConsumerConfiguration(KafkaTriggerAttribute attribute)
         {
             var consumerConfig = new KafkaListenerConfiguration()
             {

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
@@ -377,9 +377,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 new DefaultNameResolver(config),
                 NullLoggerFactory.Instance);
 
-            MethodInfo consumerConfigMethod = typeof(KafkaTriggerAttributeBindingProvider).GetMethod("CreateConsumerConfiguration", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            KafkaListenerConfiguration result = (KafkaListenerConfiguration)consumerConfigMethod.Invoke(bindingProvider, new object[] { attribute });
+            KafkaListenerConfiguration result = bindingProvider.CreateConsumerConfiguration(attribute);
 
             Assert.Equal("password1", result.SslKeyPassword);
             Assert.Equal(sslCertificate.FullName, result.SslCertificateLocation);
@@ -420,9 +418,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 new DefaultNameResolver(config),
                 NullLoggerFactory.Instance);
 
-            MethodInfo consumerConfigMethod = typeof(KafkaTriggerAttributeBindingProvider).GetMethod("CreateConsumerConfiguration", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            KafkaListenerConfiguration result = (KafkaListenerConfiguration)consumerConfigMethod.Invoke(bindingProvider, new object[] { attribute });
+            KafkaListenerConfiguration result = bindingProvider.CreateConsumerConfiguration(attribute);
 
             Assert.Equal("password1", result.SslKeyPassword);
             Assert.Equal(sslCertificate.FullName, result.SslCertificateLocation);

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using Xunit;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.Helpers;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 {
@@ -85,7 +86,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         static void ProtobufWithoutKey_Fn([KafkaTrigger("brokers:9092", "myTopic")] KafkaEventData<ProtoUser> protoUser) { }
         static void Protobuf_WithLongKey_Fn([KafkaTrigger("brokers:9092", "myTopic")] KafkaEventData<long, ProtoUser> protoUser) { }
         static void Protobuf_WithStringKey_Fn([KafkaTrigger("brokers:9092", "myTopic")] KafkaEventData<string, ProtoUser> protoUser) { }
-
 
         ParameterInfo GetParameterInfo(string methodName)
         {
@@ -350,6 +350,84 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var genericTypes = listener.GetType().GetGenericArguments();
             Assert.Equal(keyType, genericTypes[0]);
             Assert.Equal(valueType, genericTypes[1]);
+        }
+
+        [Fact]
+        public void GetConsumerConfig_When_Ssl_Locations_Resolve_Should_Contain_Full_Path()
+        {
+            var sslCertificate = this.CreateFile("sslCertificate.pem");
+            var sslCa = this.CreateFile("sslCa.pem");
+            var sslKeyLocation = this.CreateFile("sslKey.pem");
+
+            var attribute = new KafkaTriggerAttribute("brokers:9092", "myTopic")
+            {
+                Protocol = BrokerProtocol.Ssl,
+                SslKeyPassword = "password1",
+                SslCertificateLocation = sslCertificate.FullName,
+                SslCaLocation = sslCa.FullName,
+                SslKeyLocation = sslKeyLocation.FullName
+            };
+
+            var config = this.emptyConfiguration;
+
+            var bindingProvider = new KafkaTriggerAttributeBindingProvider(
+                config,
+                Options.Create(new KafkaOptions()),
+                new KafkaEventDataConvertManager(NullLogger.Instance),
+                new DefaultNameResolver(config),
+                NullLoggerFactory.Instance);
+
+            MethodInfo consumerConfigMethod = typeof(KafkaTriggerAttributeBindingProvider).GetMethod("CreateConsumerConfiguration", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            KafkaListenerConfiguration result = (KafkaListenerConfiguration)consumerConfigMethod.Invoke(bindingProvider, new object[] { attribute });
+
+            Assert.Equal("password1", result.SslKeyPassword);
+            Assert.Equal(sslCertificate.FullName, result.SslCertificateLocation);
+            Assert.Equal(sslCa.FullName, result.SslCaLocation);
+            Assert.Equal(sslKeyLocation.FullName, result.SslKeyLocation);
+        }
+
+        [Fact]
+        public void GetConsumerConfig_When_Ssl_Locations_Resolve_InAzure_Should_Contain_Full_Path()
+        {
+            AzureEnvironment.SetRunningInAzureEnvVars();
+
+            var currentFolder = Directory.GetCurrentDirectory();
+            var folder1 = Directory.CreateDirectory(Path.Combine(currentFolder, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart1));
+            Directory.CreateDirectory(Path.Combine(folder1.FullName, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart2));
+
+            AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.AzureHomeEnvVarName, currentFolder);
+
+            var sslCertificate = this.CreateFile(Path.Combine(currentFolder, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart1, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart2, "sslCertificate.pem"));
+            var sslCa = this.CreateFile(Path.Combine(currentFolder, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart1, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart2, "sslCa.pem"));
+            var sslKeyLocation = this.CreateFile(Path.Combine(currentFolder, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart1, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart2, "sslKey.pem"));
+
+            var attribute = new KafkaTriggerAttribute("brokers:9092", "myTopic")
+            {
+                Protocol = BrokerProtocol.Ssl,
+                SslKeyPassword = "password1",
+                SslCertificateLocation = sslCertificate.FullName,
+                SslCaLocation = sslCa.FullName,
+                SslKeyLocation = sslKeyLocation.FullName
+            };
+
+            var config = this.emptyConfiguration;
+
+            var bindingProvider = new KafkaTriggerAttributeBindingProvider(
+                config,
+                Options.Create(new KafkaOptions()),
+                new KafkaEventDataConvertManager(NullLogger.Instance),
+                new DefaultNameResolver(config),
+                NullLoggerFactory.Instance);
+
+            MethodInfo consumerConfigMethod = typeof(KafkaTriggerAttributeBindingProvider).GetMethod("CreateConsumerConfiguration", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            KafkaListenerConfiguration result = (KafkaListenerConfiguration)consumerConfigMethod.Invoke(bindingProvider, new object[] { attribute });
+
+            Assert.Equal("password1", result.SslKeyPassword);
+            Assert.Equal(sslCertificate.FullName, result.SslCertificateLocation);
+            Assert.Equal(sslCa.FullName, result.SslCaLocation);
+            Assert.Equal(sslKeyLocation.FullName, result.SslKeyLocation);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
@@ -18,17 +18,42 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
+using System.Collections.Generic;
+using System.IO;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 {
-    public class KafkaTriggerAttributeBindingProviderTest
+    public class KafkaTriggerAttributeBindingProviderTest : IDisposable
     {
+        private List<FileInfo> createdFiles = new List<FileInfo>();
         private IConfigurationRoot emptyConfiguration;
 
         public KafkaTriggerAttributeBindingProviderTest()
         {
             this.emptyConfiguration = new ConfigurationBuilder()
                 .Build();
+        }
+
+        public void Dispose()
+        {
+            foreach (var fi in this.createdFiles)
+            {
+                if (fi.Exists)
+                {
+                    fi.Delete();
+                }
+            }
+
+            this.createdFiles.Clear();
+        }
+
+        private FileInfo CreateFile(string fileName)
+        {
+            File.WriteAllText(fileName, "dummy contents");
+            var file = new FileInfo(fileName);
+            this.createdFiles.Add(file);
+
+            return file;
         }
 
         static void RawByteArray_Fn([KafkaTrigger("brokers:9092", "myTopic")] byte[] data) { }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
@@ -377,7 +377,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 new DefaultNameResolver(config),
                 NullLoggerFactory.Instance);
 
-            KafkaListenerConfiguration result = bindingProvider.CreateConsumerConfiguration(attribute);
+            MethodInfo consumerConfigMethod = typeof(KafkaTriggerAttributeBindingProvider).GetMethod("CreateConsumerConfiguration", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            KafkaListenerConfiguration result = (KafkaListenerConfiguration)consumerConfigMethod.Invoke(bindingProvider, new object[] { attribute });
 
             Assert.Equal("password1", result.SslKeyPassword);
             Assert.Equal(sslCertificate.FullName, result.SslCertificateLocation);
@@ -418,7 +420,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 new DefaultNameResolver(config),
                 NullLoggerFactory.Instance);
 
-            KafkaListenerConfiguration result = bindingProvider.CreateConsumerConfiguration(attribute);
+            MethodInfo consumerConfigMethod = typeof(KafkaTriggerAttributeBindingProvider).GetMethod("CreateConsumerConfiguration", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            KafkaListenerConfiguration result = (KafkaListenerConfiguration)consumerConfigMethod.Invoke(bindingProvider, new object[] { attribute });
 
             Assert.Equal("password1", result.SslKeyPassword);
             Assert.Equal(sslCertificate.FullName, result.SslCertificateLocation);


### PR DESCRIPTION
The SslCertificateLocation, SslKeyLocation and SslCaLocation attributes require the absolute path of certificate and keys respectively.  This PR makes sure that the path is absolute and fixes https://github.com/Azure/azure-functions-kafka-extension/issues/321