### PR TITLE
Improving Retry Test for Webjobs Version Upgrade

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Version>$(Version)</Version>
@@ -38,7 +38,7 @@
     <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.9.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.9.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <Version>$(Version)</Version>
@@ -38,7 +38,7 @@
     <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.9.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.9.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
@@ -1037,8 +1037,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                             Console.WriteLine(logMsg.Exception.InnerException.Message);
                         }
                     }
-                    var foundCount = loggerProvider1.GetAllLogMessages().Count(p => p.Exception != null && p.Exception.InnerException.Message.Contains("unhandled error") && !p.Category.StartsWith("Host.Results"));
-                    return foundCount == 6;
+                    var foundCount = loggerProvider1.GetAllLogMessages().Count(p => p.FormattedMessage != null &&  p.FormattedMessage.Contains($"Executed '{nameof(SingleItem_Single_Partition_Raw_String_Without_Key_Trigger_Retry)}.Trigger'"));
+					return foundCount == 6;
                 });
 
                 await Task.Delay(1500);


### PR DESCRIPTION
Issue:
Currently the End-to-End test for Retry checks if an exception is logged from the kafka function exactly Number of Retries + 1 times. Since the last upgrade, WebJobs SDK has added an additional log after all retires are exhausted to capture the last error throw. This would mean that the actual number of times the exception is logged would increase by 1 for the above test scenario - Leading to the failure of the test in case of WebJobs SDK upgrade. PR link - [https://github.com/Azure/azure-webjobs-sdk/pull/2914](https://github.com/Azure/azure-webjobs-sdk/pull/2914)

Solution:
To remove the dependency on the number of times the exception is logged - This PR introduces a change to look at the actual number of executions of the function from the logs. This is done to unblock the future WebJobs SDK upgrade scenarios. 