### PR TITLE
Re-Enabling Confluent Tests and Adding Flags to disable Lang E2E tests from Pipeline

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -140,6 +140,8 @@ steps:
       ConfluentCloudUsername: $(ConfluentCloudUsername)
       EventHubBrokerList: $(EventHubBrokerList)
       EventHubConnectionString: $(EventHubConnectionString)
+      DisableConfluentTestsFlag: $(DisableConfluentTestsFlag)
+      DisableEventHubsTestsFlag: $(DisableEventHubsTestsFlag)
 
   - task: DotNetCoreCLI@2
     displayName: Pack NuGet package

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Common/Queue/QueueManager/EventHubQueueManager.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Common/Queue/QueueManager/EventHubQueueManager.cs
@@ -83,6 +83,10 @@ public class EventHubQueueManager : IQueueManager<QueueRequest, QueueResponse>
 				await eventhub.DeleteAsync(WaitUntil.Completed);
 				return;
 			}
+			catch (RequestFailedException ex) when (ex.Status == 404) 
+			{ 
+				_logger.LogInformation($"Unable to find resources to delete for Eventhub delete Operation with exception {ex.Message}");
+			}
 			catch (Exception ex)
 			{
 				if (count >= _MAX_RETRY_COUNT)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/Facts/IgnoreOnDisableConfluentTestsFlagFact.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/Facts/IgnoreOnDisableConfluentTestsFlagFact.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests.Tests
+{
+    internal sealed class IgnoreOnDisableConfluentTestsFlagFact : FactAttribute
+    {
+        public IgnoreOnDisableConfluentTestsFlagFact()
+        {
+            if (IgnoreOnDisableConfluentFlag())
+            {
+                Skip = "Skipping Confluent tests as DisableConfluentTestsFlag is provided";
+            }
+        }
+
+        private static bool IgnoreOnDisableConfluentFlag() =>
+            Environment.GetEnvironmentVariable("DisableConfluentTestsFlag") != null;
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/Facts/IgnoreOnDisableConfluentTestsFlagFact.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/Facts/IgnoreOnDisableConfluentTestsFlagFact.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests.Tests
         }
 
         private static bool IgnoreOnDisableConfluentFlag() =>
-            Environment.GetEnvironmentVariable("DisableConfluentTestsFlag") != null;
-    }
+            Environment.GetEnvironmentVariable("DisableConfluentTestsFlag") == "true";
+        }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/Facts/IgnoreOnDisableEventHubsTestsFlagFact.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/Facts/IgnoreOnDisableEventHubsTestsFlagFact.cs
@@ -1,0 +1,22 @@
+﻿using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests.Tests
+{
+    internal sealed class IgnoreOnDisableEventHubsTestsFlagFact : FactAttribute
+    {
+        public IgnoreOnDisableEventHubsTestsFlagFact()
+        {
+            if (IgnoreOnDisableEventHubsFlag())
+            {
+                Skip = "Skipping EventHubs tests as DisableEventHubsTestsFlag is provided";
+            }
+        }
+
+        private static bool IgnoreOnDisableEventHubsFlag() =>
+            Environment.GetEnvironmentVariable("DisableEventHubsTestsFlag") == "true";
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/JavaConfluentAppTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/JavaConfluentAppTest.cs
@@ -17,7 +17,7 @@ public class JavaConfluentAppTest : BaseE2E, IClassFixture<JavaConfluentE2EFixtu
 		_output = output;
 	}
 
-	[Fact(Skip = "Not currently working due to Confluent Infra")]
+	[IgnoreOnDisableConfluentTestsFlagFact]
 	public async Task Java_App_Test_Single_Event_Confluent()
 	{
 		//Generate Random Guids
@@ -31,7 +31,7 @@ public class JavaConfluentAppTest : BaseE2E, IClassFixture<JavaConfluentE2EFixtu
 		await Test(AppType.SINGLE_EVENT, InvokeType.HTTP, httpRequestEntity, null, reqMsgs);
 	}
 
-	[Fact(Skip = "Not currently working due to Confluent Infra")]
+	[IgnoreOnDisableConfluentTestsFlagFact]
 	public async Task Java_App_Test_Multi_Event_Confluent()
 	{
 		//Generate Random Guids

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/JavaEventhubAppTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/JavaEventhubAppTest.cs
@@ -17,7 +17,7 @@ public class JavaEventhubAppTest : BaseE2E, IClassFixture<JavaEventhubE2EFixture
 		_output = output;
 	}
 
-	[Fact]
+	[IgnoreOnDisableEventHubsTestsFlagFact]
 	public async Task Java_App_Test_Single_Event_Eventhub()
 	{
 		//Generate Random Guids
@@ -33,7 +33,7 @@ public class JavaEventhubAppTest : BaseE2E, IClassFixture<JavaEventhubE2EFixture
 	}
 
 
-	[Fact]
+	[IgnoreOnDisableEventHubsTestsFlagFact]
 	public async Task Java_App_Test_Multi_Event_Eventhub()
 	{
 		//Generate Random Guids

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/PythonConfluentAppTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/PythonConfluentAppTest.cs
@@ -17,7 +17,7 @@ public class PythonConfluentAppTest : BaseE2E, IClassFixture<PythonConfluentE2EF
 		_output = output;
 	}
 
-	[Fact(Skip = "Not currently working due to Confluent Infra")]
+	[IgnoreOnDisableConfluentTestsFlagFact]
 	public async Task Python_App_Test_Single_Event_Confluent()
 	{
 		//Generate Random Guids
@@ -31,7 +31,7 @@ public class PythonConfluentAppTest : BaseE2E, IClassFixture<PythonConfluentE2EF
 		await Test(AppType.SINGLE_EVENT, InvokeType.HTTP, httpRequestEntity, null, reqMsgs);
 	}
 
-	[Fact(Skip = "Not currently working due to Confluent Infra")]
+	[IgnoreOnDisableConfluentTestsFlagFact]
 	public async Task Python_App_Test_Multi_Event_Confluent()
 	{
 		//Generate Random Guids

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/PythonEventhubAppTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Tests/PythonEventhubAppTest.cs
@@ -17,7 +17,7 @@ public class PythonEventhubAppTest : BaseE2E, IClassFixture<PythonEventhubE2EFix
 		_output = output;
 	}
 
-	[Fact]
+	[IgnoreOnDisableEventHubsTestsFlagFact]
 	public async Task Python_App_Test_Single_Event_Eventhub()
 	{
 		//Generate Random Guids
@@ -32,7 +32,7 @@ public class PythonEventhubAppTest : BaseE2E, IClassFixture<PythonEventhubE2EFix
 	}
 
 
-	[Fact]
+	[IgnoreOnDisableEventHubsTestsFlagFact]
 	public async Task Python_App_Test_Multi_Event_Confluent()
 	{
 		//Generate Random Guids


### PR DESCRIPTION
The PR contains the following changes - 
1. Re-enabling the Confluent Language End to End test cases which were disabled here - #447 
2. Adding flags in the pipeline to easily enable and disable tests in CI pipeline for future.
3. Improved logging for EventHubQueueManager.
 