### PR TITLE
Fix scale monitor descriptor function id

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaTopicScaler.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaTopicScaler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.topicName = topic;
-            this.Descriptor = new ScaleMonitorDescriptor($"{functionId}-kafkatrigger-{topicName}-{consumerGroup}".ToLower());
+            this.Descriptor = new ScaleMonitorDescriptor($"{functionId}-kafkatrigger-{topicName}-{consumerGroup}".ToLower(), functionId);
             this.consumerGroup = consumerGroup;
             this.lagThreshold = lagThreshold;
             this.metricsProvider = metricsProvider;

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTopicScalerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTopicScalerTest.cs
@@ -45,6 +45,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         [Fact]
+        public void ScaleMonitor_FunctionId_ReturnsExpectedValue()
+        {
+            Assert.Equal("testfunction", topicScaler.Descriptor.FunctionId);
+        }
+
+        [Fact]
         public void When_No_Lag_Is_Found_Should_Vote_Scale_Down()
         {
             var context = new ScaleStatusContext<KafkaTriggerMetrics>()


### PR DESCRIPTION
Hello everyone,

The KafkaTargetScaler is using the obsolete [ScaleMonitorDescriptor](https://github.com/Azure/azure-webjobs-sdk/blob/8ef02d5a3a78056f9ec5a2bc9459b9600c0a0309/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleMonitorDescriptor.cs#L19) constructor without the functionId parameter.

```csharp
[Obsolete("This constructor is obsolete. Use the version that takes function id instead.")]
public ScaleMonitorDescriptor(string id)
{
	Id = id;
}

public ScaleMonitorDescriptor(string id, string functionId) : this(id)
{
	FunctionId = functionId;
}
```

```csharp

```

When target scaling is enabled (by default) the [ScaleManager](https://github.com/Azure/azure-webjobs-sdk/blob/8ef02d5a3a78056f9ec5a2bc9459b9600c0a0309/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleManager.cs#L237-L238) compares the FunctionId to evaluate if a `ScaleMonitor` is used in case a `TargetScaler` already exists. But for the same function, the FunctionId of the TargetScaler and ScaleMonitor are not equal.

```csharp
// Check if TBS enabled on app level
if (scaleOptions.Value.IsTargetScalingEnabled)
{
	HashSet<string> targetScalerFunctions = new HashSet<string>();
	foreach (var scaler in targetScalers)
	{
		string scalerUniqueId = GetTargetScalerFunctionUniqueId(scaler);
		if (!_targetScalersInError.Contains(scalerUniqueId))
		{
			string assemblyName = GetAssemblyName(scaler.GetType());
			bool featureDisabled = configuration.GetValue<string>(assemblyName) == "0";
			if (!featureDisabled)
			{
				targetScalersToSample.Add(scaler);
				targetScalerFunctions.Add(scalerUniqueId);
			}
		}
	}

	foreach (var monitor in scaleMonitors)
	{
		string monitorUniqueId = GetScaleMonitorFunctionUniqueId(monitor);
		// Check if target based scaler exists for the function
		if (!targetScalerFunctions.Contains(monitorUniqueId))
		{
			scaleMonitorsToSample.Add(monitor);
		}
	}
}
```

Both `ScaleMonitor` and `TargetScaler` are retrieved for sampling. It leads to a bad behavior as the [ScaleManager](https://github.com/Azure/azure-webjobs-sdk/blob/8ef02d5a3a78056f9ec5a2bc9459b9600c0a0309/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleManager.cs#L74-L75) doesn't use the `TargetScaler` to override the vote result when there is any `ScaleMonitor` status.

```csharp
// Set correct vote if all the triggers are target
if (!scaleStatuses.Any() && aggregateScaleStatus.TargetWorkerCount.HasValue)
{
    aggregateScaleStatus.Vote = (ScaleVote)aggregateScaleStatus.TargetWorkerCount.Value.CompareTo(context.WorkerCount);
}
```
Example of a bad result on `/admin/host/scale/status` function runtime endpoint:
```json
{
    "vote": 0,
    "targetWorkerCount": 4,
    "functionScaleStatuses": {
        "my.functions.myfirstfunction.runasync-kafkatrigger-topic.myconsumer": {
            "vote": 0
        },
        "my.functions.mysecondfunction.runasync-kafkatrigger-topic.myconsumer": {
            "vote": 0
        }
    },
    "functionTargetScalerResults": {
        "My.Functions.MyFirstFunction.RunAsync": {
            "targetWorkerCount": 4
        },
        "My.Functions.MySecondFunction.RunAsync": {
            "targetWorkerCount": 1
        }
    }
}
```

