### PR TITLE
Fix Docker Compose Failure in Build Pipeline

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -105,13 +105,20 @@ extends:
           #     filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
           #     workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
           
-          - task: DockerCompose@1
+          # - task: DockerCompose@1
+          #   displayName: Start Kafka in single node
+          #   inputs:
+          #     containerType: 'inline'
+          #     inlineScript: |
+          #       docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml up -d
+          
+          - task: PowerShell@2
             displayName: Start Kafka in single node
             inputs:
-              containerType: 'inline'
-              inlineScript: |
+              targetType: 'inline'
+              script: |
                 docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml up -d
-          
+
           - task: DotNetCoreCLI@2
             displayName: Run e2e tests
             inputs:
@@ -125,11 +132,18 @@ extends:
           #     filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/stop-kafka-test-environment.sh
           #     workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
-          - task: DockerCompose@1
+          # - task: DockerCompose@1
+          #   displayName: Stop Kafka in single node
+          #   inputs:
+          #     containerType: 'inline'
+          #     inlineScript: |
+          #       docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml down
+
+          - task: PowerShell@2
             displayName: Stop Kafka in single node
             inputs:
-              containerType: 'inline'
-              inlineScript: |
+              targetType: 'inline'
+              script: |
                 docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml down
           
           - task: DotNetCoreCLI@2

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -98,26 +98,40 @@ extends:
               command: test
               projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
-          - task: Bash@3
+          # - task: Bash@3
+          #   displayName: Start Kafka in single node
+          #   inputs:
+          #     targetType: filePath
+          #     filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
+          #     workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
+          
+          - task: DockerCompose@1
             displayName: Start Kafka in single node
             inputs:
-              targetType: filePath
-              filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
-              workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
-
+              containerType: 'inline'
+              inlineScript: |
+                docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml up -d
+          
           - task: DotNetCoreCLI@2
             displayName: Run e2e tests
             inputs:
               command: test
               projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
-          - task: Bash@3
+          # - task: Bash@3
+          #   displayName: Stop Kafka in single node
+          #   inputs:
+          #     targetType: filePath
+          #     filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/stop-kafka-test-environment.sh
+          #     workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
+
+          - task: DockerCompose@1
             displayName: Stop Kafka in single node
             inputs:
-              targetType: filePath
-              filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/stop-kafka-test-environment.sh
-              workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
-
+              containerType: 'inline'
+              inlineScript: |
+                docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml down
+          
           - task: DotNetCoreCLI@2
             displayName: Pack NuGet package
             inputs:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -104,20 +104,6 @@ extends:
               targetType: filePath
               filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
               workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
-          
-          # - task: DockerCompose@1
-          #   displayName: Start Kafka in single node
-          #   inputs:
-          #     containerType: 'inline'
-          #     inlineScript: |
-          #       docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml up -d
-          
-          # - task: PowerShell@2
-          #   displayName: Start Kafka in single node
-          #   inputs:
-          #     targetType: 'inline'
-          #     script: |
-          #       docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml up -d
 
           - task: DotNetCoreCLI@2
             displayName: Run e2e tests
@@ -132,20 +118,6 @@ extends:
               filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/stop-kafka-test-environment.sh
               workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
-          # - task: DockerCompose@1
-          #   displayName: Stop Kafka in single node
-          #   inputs:
-          #     containerType: 'inline'
-          #     inlineScript: |
-          #       docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml down
-
-          # - task: PowerShell@2
-          #   displayName: Stop Kafka in single node
-          #   inputs:
-          #     targetType: 'inline'
-          #     script: |
-          #       docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml down
-          
           - task: DotNetCoreCLI@2
             displayName: Pack NuGet package
             inputs:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -98,12 +98,12 @@ extends:
               command: test
               projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
-          # - task: Bash@3
-          #   displayName: Start Kafka in single node
-          #   inputs:
-          #     targetType: filePath
-          #     filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
-          #     workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
+          - task: Bash@3
+            displayName: Start Kafka in single node
+            inputs:
+              targetType: filePath
+              filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
+              workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
           
           # - task: DockerCompose@1
           #   displayName: Start Kafka in single node
@@ -112,12 +112,12 @@ extends:
           #     inlineScript: |
           #       docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml up -d
           
-          - task: PowerShell@2
-            displayName: Start Kafka in single node
-            inputs:
-              targetType: 'inline'
-              script: |
-                docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml up -d
+          # - task: PowerShell@2
+          #   displayName: Start Kafka in single node
+          #   inputs:
+          #     targetType: 'inline'
+          #     script: |
+          #       docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml up -d
 
           - task: DotNetCoreCLI@2
             displayName: Run e2e tests
@@ -125,12 +125,12 @@ extends:
               command: test
               projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
-          # - task: Bash@3
-          #   displayName: Stop Kafka in single node
-          #   inputs:
-          #     targetType: filePath
-          #     filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/stop-kafka-test-environment.sh
-          #     workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
+          - task: Bash@3
+            displayName: Stop Kafka in single node
+            inputs:
+              targetType: filePath
+              filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/stop-kafka-test-environment.sh
+              workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
           # - task: DockerCompose@1
           #   displayName: Stop Kafka in single node
@@ -139,12 +139,12 @@ extends:
           #     inlineScript: |
           #       docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml down
 
-          - task: PowerShell@2
-            displayName: Stop Kafka in single node
-            inputs:
-              targetType: 'inline'
-              script: |
-                docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml down
+          # - task: PowerShell@2
+          #   displayName: Stop Kafka in single node
+          #   inputs:
+          #     targetType: 'inline'
+          #     script: |
+          #       docker-compose -f test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/docker-compose.yml down
           
           - task: DotNetCoreCLI@2
             displayName: Pack NuGet package

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
@@ -2,6 +2,8 @@
 
 export COMPOSE_INTERACTIVE_NO_CLI=1
 
+apt install -y docker-compose
+
 # start docker compose
 docker-compose -f ./kafka-singlenode-compose.yaml  up --build -d
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
@@ -5,7 +5,7 @@ export COMPOSE_INTERACTIVE_NO_CLI=1
 apt install -y docker-compose
 
 # start docker compose
-docker-compose -f ./kafka-singlenode-compose.yaml  up --build -d
+./docker-compose -f ./kafka-singlenode-compose.yaml  up --build -d
 
 # wait until kafka is ready to create topic
 # need to improve, adding a retry instead of a static sleep

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
@@ -5,7 +5,7 @@ export COMPOSE_INTERACTIVE_NO_CLI=1
 sudo apt install -y docker-compose
 
 # start docker compose
-./docker-compose -f ./kafka-singlenode-compose.yaml  up --build -d
+docker-compose -f ./kafka-singlenode-compose.yaml  up --build -d
 
 # wait until kafka is ready to create topic
 # need to improve, adding a retry instead of a static sleep

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
@@ -2,7 +2,7 @@
 
 export COMPOSE_INTERACTIVE_NO_CLI=1
 
-apt install -y docker-compose
+sudo apt install -y docker-compose
 
 # start docker compose
 ./docker-compose -f ./kafka-singlenode-compose.yaml  up --build -d


### PR DESCRIPTION
Updated the start kafka container script to explicitly install the docker compose. Tested the build succeeds with build on the branch. The pipeline sometimes still faces the issue of request throttling from docker hub.  