### PR TITLE
Update framework and package versions used in dotnet in-proc sample

### DIFF
--- a/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
+++ b/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.9.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.9.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
   </ItemGroup>
    <ItemGroup>
     <None Update="cacert.pem">

--- a/samples/dotnet/ConsoleConsumer/MagicAvroDeserializer.cs
+++ b/samples/dotnet/ConsoleConsumer/MagicAvroDeserializer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using Confluent.Kafka;
 
 namespace ConsoleConsumer

--- a/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
+++ b/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.9.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.9.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="1.9.0" />
+	  <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
+	  <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
+	  <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
+	  <PackageReference Include="Google.Protobuf" Version="3.29.1" />
   </ItemGroup>
    <ItemGroup>
     <None Update="cacert.pem">

--- a/samples/dotnet/ConsoleProducer/Program.cs
+++ b/samples/dotnet/ConsoleProducer/Program.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace ConsoleProducer

--- a/samples/dotnet/ConsoleProducer/ProtobufTopicProducer.cs
+++ b/samples/dotnet/ConsoleProducer/ProtobufTopicProducer.cs
@@ -5,7 +5,6 @@ using Confluent.Kafka;
 
 namespace ConsoleProducer
 {
-
     public class ProtobufTopicProducer : ITopicProducer
     {
         private readonly string brokerList;

--- a/samples/dotnet/ConsoleProducer/StringTopicProducer.cs
+++ b/samples/dotnet/ConsoleProducer/StringTopicProducer.cs
@@ -5,7 +5,6 @@ using Confluent.Kafka;
 
 namespace ConsoleProducer
 {
-
     public class StringTopicProducer : ITopicProducer
     {
         private readonly string brokerList;

--- a/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
+++ b/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="host.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Microsoft.Azure.WebJobs.Extensions.Kafka\Microsoft.Azure.WebJobs.Extensions.Kafka.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<AzureFunctionsVersion>v4</AzureFunctionsVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.5.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Update="host.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="local.settings.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<CopyToPublishDirectory>Never</CopyToPublishDirectory>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\src\Microsoft.Azure.WebJobs.Extensions.Kafka\Microsoft.Azure.WebJobs.Extensions.Kafka.csproj" />
+	</ItemGroup>
 </Project>

--- a/samples/dotnet/SampleHost/SampleHost.csproj
+++ b/samples/dotnet/SampleHost/SampleHost.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes made to dotnet inproc sample:
- Removed unused directives from sample consumer and producer console apps
- Updated all packages in project to recent versions (taken from [NugetGallery](https://www.nuget.org/packages))
- Migrated functions host v3 to v4 (ref: [Migrate apps from Azure Functions version 3.x to 4.x | Microsoft Learn](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-version-3-version-4?tabs=net8%2Cazure-cli%2Cwindows&pivots=programming-language-csharp))

Tested using docker run local kafka server (https://wurstmeister.github.io/kafka-docker/)