### PR TITLE
Allow tombstone events to appear as empty arrays 

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaEventDataConvertManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaEventDataConvertManager.cs
@@ -100,6 +100,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             {
                 result = bytes;
             }
+            else if (value is null)
+            {
+                result = new byte[0];
+            }
             else if (value is string stringValue)
             {
                 result = Encoding.UTF8.GetBytes(stringValue);


### PR DESCRIPTION
Allow tombstone events to appear as empty arrays when using `byte[][]` parameter in KafkaTrigger

Solves https://github.com/Azure/azure-functions-kafka-extension/issues/545.