### PR TITLE
feat: At-least-once delivery for Kafka trigger with maxRetries poison message protection

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -209,6 +209,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             }
         }
 
+        /// <summary>
+        /// Gets or sets whether to commit offsets when function execution fails.
+        /// When false (default), failed messages will be redelivered (at-least-once).
+        /// When true, offsets are always committed regardless of function result (at-most-once, legacy behavior).
+        /// Default: false
+        /// </summary>
+        public bool CommitOnFailure { get; set; } = false;
+
+        int maxRetries = 5;
+        /// <summary>
+        /// Gets or sets the maximum number of times a failed message will be redelivered
+        /// before the offset is force-committed (message skipped).
+        /// Only applies when CommitOnFailure is false.
+        /// Set to -1 for unlimited retries (not recommended — risk of infinite loop).
+        /// Default: 5
+        /// </summary>
+        public int MaxRetries
+        {
+            get => this.maxRetries;
+            set
+            {
+                if (value < -1)
+                {
+                    throw new InvalidOperationException("MaxRetries must be -1 (unlimited) or a non-negative integer.");
+                }
+
+                this.maxRetries = value;
+            }
+        }
+
         int channelFullRetryIntervalInMs = 50;
         /// <summary>
         /// Defines the interval in milliseconds in which the subscriber should retry adding items to channel once it reaches the capacity

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -211,11 +211,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         /// <summary>
         /// Gets or sets whether to commit offsets when function execution fails.
-        /// When false (default), failed messages will be redelivered (at-least-once).
-        /// When true, offsets are always committed regardless of function result (at-most-once, legacy behavior).
-        /// Default: false
+        /// When true (default), offsets are always committed regardless of function result (at-most-once).
+        /// When false, failed messages will be retried in-place up to MaxRetries times (at-least-once).
+        /// Default: true
         /// </summary>
-        public bool CommitOnFailure { get; set; } = false;
+        public bool CommitOnFailure { get; set; } = true;
 
         int maxRetries = 5;
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -156,8 +156,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             var commitStrategy = new AsyncCommitStrategy<TKey, TValue>(localConsumer, this.logger);
 
             this.functionExecutor = singleDispatch ?
-                (FunctionExecutorBase<TKey, TValue>)new SingleItemFunctionExecutor<TKey, TValue>(executor, localConsumer, this.consumerGroup, this.options.ExecutorChannelCapacity, this.options.ChannelFullRetryIntervalInMs, commitStrategy, logger, drainModeManager) :
-                new MultipleItemFunctionExecutor<TKey, TValue>(executor, localConsumer, this.consumerGroup, this.options.ExecutorChannelCapacity, this.options.ChannelFullRetryIntervalInMs, commitStrategy, logger, drainModeManager);
+                (FunctionExecutorBase<TKey, TValue>)new SingleItemFunctionExecutor<TKey, TValue>(executor, localConsumer, this.consumerGroup, this.options.ExecutorChannelCapacity, this.options.ChannelFullRetryIntervalInMs, commitStrategy, logger, drainModeManager, this.options) :
+                new MultipleItemFunctionExecutor<TKey, TValue>(executor, localConsumer, this.consumerGroup, this.options.ExecutorChannelCapacity, this.options.ChannelFullRetryIntervalInMs, commitStrategy, logger, drainModeManager, this.options);
 
             localConsumer.Subscribe(this.listenerConfiguration.Topic);
             // Using a thread as opposed to a task since this will be long running

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/FunctionExecutorBase.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/FunctionExecutorBase.cs
@@ -153,10 +153,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         }
 
         /// <summary>
-        /// Checks if the message at the given offset has exceeded max retries.
-        /// If maxRetries is -1 (unlimited), always returns false.
+        /// Increments the retry counter for the given offset and checks if max retries has been exceeded.
+        /// If maxRetries is -1 (unlimited), always returns false without incrementing.
         /// </summary>
-        protected bool HasExceededMaxRetries(string topic, int partition, long offset)
+        protected bool IncrementRetryAndCheckExceeded(string topic, int partition, long offset)
         {
             if (this.options.MaxRetries < 0)
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/FunctionExecutorBase.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/FunctionExecutorBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
@@ -26,9 +27,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         private readonly CancellationTokenSource functionExecutionCancellationTokenSource;
         private readonly Channel<IKafkaEventData[]> channel;
         private readonly List<IKafkaEventData> currentBatch;
-        private readonly ILogger logger;
+        protected readonly ILogger logger;
         private readonly IDrainModeManager drainModeManager;
         private SemaphoreSlim readerFinished = new SemaphoreSlim(0, 1);
+        protected readonly KafkaOptions options;
+        private readonly ConcurrentDictionary<string, int> retryCounters = new ConcurrentDictionary<string, int>();
 
         internal FunctionExecutorBase(
             ITriggeredFunctionExecutor executor,
@@ -37,7 +40,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             int channelFullRetryIntervalInMs,
             ICommitStrategy<TKey, TValue> commitStrategy,
             ILogger logger,
-            IDrainModeManager drainModeManager)
+            IDrainModeManager drainModeManager,
+            KafkaOptions options)
         {
             this.executor = executor ?? throw new System.ArgumentNullException(nameof(executor));
             this.consumer = consumer ?? throw new System.ArgumentNullException(nameof(consumer));
@@ -47,6 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             this.functionExecutionCancellationTokenSource = new CancellationTokenSource();
             this.currentBatch = new List<IKafkaEventData>();
             this.drainModeManager = drainModeManager;
+            this.options = options ?? new KafkaOptions();
 
             this.channel = Channel.CreateBounded<IKafkaEventData[]>(new BoundedChannelOptions(channelCapacity)
             {
@@ -144,8 +149,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         protected Task<FunctionResult> ExecuteFunctionAsync(TriggeredFunctionData triggerData, CancellationToken cancellationToken)
         {
-            // TODO: add retry logic
             return this.executor.TryExecuteAsync(triggerData, cancellationToken);
+        }
+
+        /// <summary>
+        /// Checks if the message at the given offset has exceeded max retries.
+        /// If maxRetries is -1 (unlimited), always returns false.
+        /// </summary>
+        protected bool HasExceededMaxRetries(string topic, int partition, long offset)
+        {
+            if (this.options.MaxRetries < 0)
+            {
+                return false;
+            }
+
+            var key = $"{topic}/{partition}/{offset}";
+            var count = this.retryCounters.AddOrUpdate(key, 1, (_, c) => c + 1);
+            return count > this.options.MaxRetries;
+        }
+
+        /// <summary>
+        /// Clears the retry counter for a successfully processed offset.
+        /// </summary>
+        protected void ClearRetryCounter(string topic, int partition, long offset)
+        {
+            var key = $"{topic}/{partition}/{offset}";
+            this.retryCounters.TryRemove(key, out _);
         }
 
         bool isClosed = false;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
@@ -103,41 +103,62 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                             }
                             else if (this.options.CommitOnFailure)
                             {
-                                // Legacy at-most-once behavior
+                                // Default at-most-once behavior: commit regardless of failure
                                 this.Commit(offsetsToCommit.Values);
                             }
                             else
                             {
-                                // Check if any offset in the batch has exceeded max retries
-                                var anyExceeded = offsetsToCommit.Values.Any(tpo =>
-                                    this.IncrementRetryAndCheckExceeded(tpo.Topic, tpo.Partition, tpo.Offset - 1));
+                                // At-least-once: retry the batch in-place
+                                var retryCommitted = false;
+                                while (!retryCommitted && !cancellationToken.IsCancellationRequested)
+                                {
+                                    // Check if any offset in the batch has exceeded max retries
+                                    var anyExceeded = offsetsToCommit.Values.Any(tpo =>
+                                        this.IncrementRetryAndCheckExceeded(tpo.Topic, tpo.Partition, tpo.Offset - 1));
 
-                                if (anyExceeded)
-                                {
-                                    logger.LogError(functionResult.Exception,
-                                        "Batch execution failed with {batchSize} items in {topic} / {partitions} / {offsets} " +
-                                        "and max retries ({maxRetries}) exceeded. Offsets will be force-committed. " +
-                                        "Consider implementing dead-letter handling in your function code.",
-                                        itemsToExecute.Length,
-                                        itemsToExecute[0].Topic,
-                                        string.Join(",", offsetsToCommit.Keys),
-                                        string.Join(",", offsetsToCommit.Values.Select(x => x.Offset)),
-                                        this.options.MaxRetries);
-                                    foreach (var tpo in offsetsToCommit.Values)
+                                    if (anyExceeded)
                                     {
-                                        this.ClearRetryCounter(tpo.Topic, tpo.Partition, tpo.Offset - 1);
+                                        logger.LogError(functionResult.Exception,
+                                            "Batch execution failed with {batchSize} items in {topic} / {partitions} / {offsets} " +
+                                            "and max retries ({maxRetries}) exceeded. Offsets will be force-committed. " +
+                                            "Consider implementing dead-letter handling in your function code.",
+                                            itemsToExecute.Length,
+                                            itemsToExecute[0].Topic,
+                                            string.Join(",", offsetsToCommit.Keys),
+                                            string.Join(",", offsetsToCommit.Values.Select(x => x.Offset)),
+                                            this.options.MaxRetries);
+                                        foreach (var tpo in offsetsToCommit.Values)
+                                        {
+                                            this.ClearRetryCounter(tpo.Topic, tpo.Partition, tpo.Offset - 1);
+                                        }
+                                        this.Commit(offsetsToCommit.Values);
+                                        retryCommitted = true;
                                     }
-                                    this.Commit(offsetsToCommit.Values);
-                                }
-                                else
-                                {
-                                    logger.LogWarning(functionResult.Exception,
-                                        "Function execution failed with {batchSize} items in {topic} / {partitions} / {offsets}. " +
-                                        "Offsets will not be committed and the messages will be redelivered.",
-                                        itemsToExecute.Length,
-                                        itemsToExecute[0].Topic,
-                                        string.Join(",", offsetsToCommit.Keys),
-                                        string.Join(",", offsetsToCommit.Values.Select(x => x.Offset)));
+                                    else
+                                    {
+                                        logger.LogWarning(functionResult.Exception,
+                                            "Function execution failed with {batchSize} items in {topic} / {partitions} / {offsets}. " +
+                                            "Batch will be retried in-place.",
+                                            itemsToExecute.Length,
+                                            itemsToExecute[0].Topic,
+                                            string.Join(",", offsetsToCommit.Keys),
+                                            string.Join(",", offsetsToCommit.Values.Select(x => x.Offset)));
+
+                                        // Re-execute the batch
+                                        triggerInput = KafkaTriggerInput.New(itemsToExecute);
+                                        triggerData = new TriggeredFunctionData { TriggerValue = triggerInput };
+                                        functionResult = await this.ExecuteFunctionAsync(triggerData, cancellationToken);
+
+                                        if (functionResult.Succeeded)
+                                        {
+                                            foreach (var tpo in offsetsToCommit.Values)
+                                            {
+                                                this.ClearRetryCounter(tpo.Topic, tpo.Partition, tpo.Offset - 1);
+                                            }
+                                            this.Commit(offsetsToCommit.Values);
+                                            retryCommitted = true;
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
     {
         private readonly string consumerGroup;
 
-        public MultipleItemFunctionExecutor(ITriggeredFunctionExecutor executor, IConsumer<TKey, TValue> consumer,  string consumerGroup, int channelCapacity, int channelFullRetryIntervalInMs, ICommitStrategy<TKey, TValue> commitStrategy, ILogger logger, IDrainModeManager drainModeManager) 
-            : base(executor, consumer, channelCapacity, channelFullRetryIntervalInMs, commitStrategy, logger, drainModeManager)
+        public MultipleItemFunctionExecutor(ITriggeredFunctionExecutor executor, IConsumer<TKey, TValue> consumer,  string consumerGroup, int channelCapacity, int channelFullRetryIntervalInMs, ICommitStrategy<TKey, TValue> commitStrategy, ILogger logger, IDrainModeManager drainModeManager, KafkaOptions options) 
+            : base(executor, consumer, channelCapacity, channelFullRetryIntervalInMs, commitStrategy, logger, drainModeManager, options)
         {
             this.consumerGroup = consumerGroup;
             logger.LogInformation($"FunctionExecutor Loaded: {nameof(MultipleItemFunctionExecutor<TKey, TValue>)}");
@@ -84,10 +84,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
                         if (!cancellationToken.IsCancellationRequested)
                         {
-                            this.Commit(offsetsToCommit.Values);
-
                             if (functionResult.Succeeded)
                             {
+                                foreach (var tpo in offsetsToCommit.Values)
+                                {
+                                    this.ClearRetryCounter(tpo.Topic, tpo.Partition, tpo.Offset - 1);
+                                }
+                                this.Commit(offsetsToCommit.Values);
+
                                 if (logger.IsEnabled(LogLevel.Debug))
                                 {
                                     logger.LogDebug("Function executed with {batchSize} items in {topic} / {partitions} / {offsets}",
@@ -97,13 +101,44 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                                         string.Join(",", offsetsToCommit.Values.Select(x => x.Offset)));
                                 }
                             }
+                            else if (this.options.CommitOnFailure)
+                            {
+                                // Legacy at-most-once behavior
+                                this.Commit(offsetsToCommit.Values);
+                            }
                             else
                             {
-                                logger.LogError(functionResult.Exception, "Failed to executed function with {batchSize} items in {topic} / {partitions} / {offsets}",
-                                    itemsToExecute.Length,
-                                    itemsToExecute[0].Topic,
-                                    string.Join(",", offsetsToCommit.Keys),
-                                    string.Join(",", offsetsToCommit.Values.Select(x => x.Offset)));
+                                // Check if any offset in the batch has exceeded max retries
+                                var anyExceeded = offsetsToCommit.Values.Any(tpo =>
+                                    this.HasExceededMaxRetries(tpo.Topic, tpo.Partition, tpo.Offset - 1));
+
+                                if (anyExceeded)
+                                {
+                                    logger.LogError(functionResult.Exception,
+                                        "Batch execution failed with {batchSize} items in {topic} / {partitions} / {offsets} " +
+                                        "and max retries ({maxRetries}) exceeded. Offsets will be force-committed. " +
+                                        "Consider implementing dead-letter handling in your function code.",
+                                        itemsToExecute.Length,
+                                        itemsToExecute[0].Topic,
+                                        string.Join(",", offsetsToCommit.Keys),
+                                        string.Join(",", offsetsToCommit.Values.Select(x => x.Offset)),
+                                        this.options.MaxRetries);
+                                    foreach (var tpo in offsetsToCommit.Values)
+                                    {
+                                        this.ClearRetryCounter(tpo.Topic, tpo.Partition, tpo.Offset - 1);
+                                    }
+                                    this.Commit(offsetsToCommit.Values);
+                                }
+                                else
+                                {
+                                    logger.LogWarning(functionResult.Exception,
+                                        "Function execution failed with {batchSize} items in {topic} / {partitions} / {offsets}. " +
+                                        "Offsets will not be committed and the messages will be redelivered.",
+                                        itemsToExecute.Length,
+                                        itemsToExecute[0].Topic,
+                                        string.Join(",", offsetsToCommit.Keys),
+                                        string.Join(",", offsetsToCommit.Values.Select(x => x.Offset)));
+                                }
                             }
                         }
                     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/MultipleItemFunctionExecutor.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                             {
                                 // Check if any offset in the batch has exceeded max retries
                                 var anyExceeded = offsetsToCommit.Values.Any(tpo =>
-                                    this.HasExceededMaxRetries(tpo.Topic, tpo.Partition, tpo.Offset - 1));
+                                    this.IncrementRetryAndCheckExceeded(tpo.Topic, tpo.Partition, tpo.Offset - 1));
 
                                 if (anyExceeded)
                                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/SingleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/SingleItemFunctionExecutor.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                         // Legacy at-most-once behavior
                         this.Commit(new[] { new TopicPartitionOffset(topicPartition, kafkaEventData.Offset + 1) });
                     }
-                    else if (this.HasExceededMaxRetries(kafkaEventData.Topic, partition, kafkaEventData.Offset))
+                    else if (this.IncrementRetryAndCheckExceeded(kafkaEventData.Topic, partition, kafkaEventData.Offset))
                     {
                         // Poison message — max retries exceeded, force-commit to skip
                         logger.LogError(functionResult.Exception,

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/SingleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/SingleItemFunctionExecutor.cs
@@ -70,54 +70,53 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             TopicPartition topicPartition = null;
             foreach (var kafkaEventData in events)
             {
-                var triggerInput = KafkaTriggerInput.New(kafkaEventData);
-                var triggerData = new TriggeredFunctionData
-                {
-                    TriggerValue = triggerInput,
-                };
-
-                // Create Single Event Activity Provider and Start the activity
-                var singleEventActivityProvider = new SingleEventActivityProvider(kafkaEventData, consumerGroup);
-                singleEventActivityProvider.StartActivity();
-                FunctionResult functionResult = null;
-                try
-                {
-                    // Execute the Function
-                    functionResult = await this.ExecuteFunctionAsync(triggerData, cancellationToken);
-                    // Set the status of activity.
-                    singleEventActivityProvider.SetActivityStatus(functionResult.Succeeded, functionResult.Exception);
-                }
-                catch (Exception ex)
-                {
-                    singleEventActivityProvider.SetActivityStatus(false, ex);
-                    throw;
-                }
-                finally
-                {
-                    // Stop the activity
-                    singleEventActivityProvider.StopCurrentActivity();
-                }
-
                 if (topicPartition == null)
                 {
                     topicPartition = new TopicPartition(kafkaEventData.Topic, partition);
                 }
 
-                // Commiting after each function execution plays nicer with function scaler.
-                // When processing a large batch of events where the execution of each event takes time
-                // it would take Events_In_Batch_For_Partition * Event_Processing_Time to update the current offset.
-                // Doing it after each event minimizes the delay
-                if (!cancellationToken.IsCancellationRequested)
+                var committed = false;
+                while (!committed && !cancellationToken.IsCancellationRequested)
                 {
+                    var triggerInput = KafkaTriggerInput.New(kafkaEventData);
+                    var triggerData = new TriggeredFunctionData
+                    {
+                        TriggerValue = triggerInput,
+                    };
+
+                    // Create Single Event Activity Provider and Start the activity
+                    var singleEventActivityProvider = new SingleEventActivityProvider(kafkaEventData, consumerGroup);
+                    singleEventActivityProvider.StartActivity();
+                    FunctionResult functionResult = null;
+                    try
+                    {
+                        // Execute the Function
+                        functionResult = await this.ExecuteFunctionAsync(triggerData, cancellationToken);
+                        // Set the status of activity.
+                        singleEventActivityProvider.SetActivityStatus(functionResult.Succeeded, functionResult.Exception);
+                    }
+                    catch (Exception ex)
+                    {
+                        singleEventActivityProvider.SetActivityStatus(false, ex);
+                        throw;
+                    }
+                    finally
+                    {
+                        // Stop the activity
+                        singleEventActivityProvider.StopCurrentActivity();
+                    }
+
                     if (functionResult.Succeeded)
                     {
                         this.ClearRetryCounter(kafkaEventData.Topic, partition, kafkaEventData.Offset);
                         this.Commit(new[] { new TopicPartitionOffset(topicPartition, kafkaEventData.Offset + 1) });
+                        committed = true;
                     }
                     else if (this.options.CommitOnFailure)
                     {
-                        // Legacy at-most-once behavior
+                        // Default at-most-once behavior: commit regardless of failure
                         this.Commit(new[] { new TopicPartitionOffset(topicPartition, kafkaEventData.Offset + 1) });
+                        committed = true;
                     }
                     else if (this.IncrementRetryAndCheckExceeded(kafkaEventData.Topic, partition, kafkaEventData.Offset))
                     {
@@ -129,15 +128,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                             kafkaEventData.Topic, partition, kafkaEventData.Offset, this.options.MaxRetries);
                         this.ClearRetryCounter(kafkaEventData.Topic, partition, kafkaEventData.Offset);
                         this.Commit(new[] { new TopicPartitionOffset(topicPartition, kafkaEventData.Offset + 1) });
+                        committed = true;
                     }
                     else
                     {
-                        // At-least-once: skip commit, message will be redelivered
+                        // At-least-once: retry the same message in-place
                         logger.LogWarning(functionResult.Exception,
                             "Function execution failed for {topic} / {partition} / {offset}. " +
-                            "Offset will not be committed and the message will be redelivered.",
+                            "Message will be retried in-place.",
                             kafkaEventData.Topic, partition, kafkaEventData.Offset);
-                        break;  // Stop processing remaining events in this partition
                     }
                 }
             }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/SingleItemFunctionExecutor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/SingleItemFunctionExecutor.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
     {
         private readonly string consumerGroup;
 
-        public SingleItemFunctionExecutor(ITriggeredFunctionExecutor executor, IConsumer<TKey, TValue> consumer, string consumerGroup, int channelCapacity, int channelFullRetryIntervalInMs, ICommitStrategy<TKey, TValue> commitStrategy, ILogger logger, IDrainModeManager drainModeManager)
-            : base(executor, consumer, channelCapacity, channelFullRetryIntervalInMs, commitStrategy, logger, drainModeManager)
+        public SingleItemFunctionExecutor(ITriggeredFunctionExecutor executor, IConsumer<TKey, TValue> consumer, string consumerGroup, int channelCapacity, int channelFullRetryIntervalInMs, ICommitStrategy<TKey, TValue> commitStrategy, ILogger logger, IDrainModeManager drainModeManager, KafkaOptions options)
+            : base(executor, consumer, channelCapacity, channelFullRetryIntervalInMs, commitStrategy, logger, drainModeManager, options)
         {
             this.consumerGroup = consumerGroup;
             logger.LogInformation($"FunctionExecutor Loaded: {nameof(SingleItemFunctionExecutor<TKey, TValue>)}");
@@ -109,7 +109,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 // Doing it after each event minimizes the delay
                 if (!cancellationToken.IsCancellationRequested)
                 {
-                    this.Commit(new[] { new TopicPartitionOffset(topicPartition, kafkaEventData.Offset + 1) });  // offset is inclusive when resuming
+                    if (functionResult.Succeeded)
+                    {
+                        this.ClearRetryCounter(kafkaEventData.Topic, partition, kafkaEventData.Offset);
+                        this.Commit(new[] { new TopicPartitionOffset(topicPartition, kafkaEventData.Offset + 1) });
+                    }
+                    else if (this.options.CommitOnFailure)
+                    {
+                        // Legacy at-most-once behavior
+                        this.Commit(new[] { new TopicPartitionOffset(topicPartition, kafkaEventData.Offset + 1) });
+                    }
+                    else if (this.HasExceededMaxRetries(kafkaEventData.Topic, partition, kafkaEventData.Offset))
+                    {
+                        // Poison message — max retries exceeded, force-commit to skip
+                        logger.LogError(functionResult.Exception,
+                            "Message at {topic} / {partition} / {offset} failed after {maxRetries} retries. " +
+                            "Offset will be force-committed and the message will be skipped. " +
+                            "Consider implementing dead-letter handling in your function code.",
+                            kafkaEventData.Topic, partition, kafkaEventData.Offset, this.options.MaxRetries);
+                        this.ClearRetryCounter(kafkaEventData.Topic, partition, kafkaEventData.Offset);
+                        this.Commit(new[] { new TopicPartitionOffset(topicPartition, kafkaEventData.Offset + 1) });
+                    }
+                    else
+                    {
+                        // At-least-once: skip commit, message will be redelivered
+                        logger.LogWarning(functionResult.Exception,
+                            "Function execution failed for {topic} / {partition} / {offset}. " +
+                            "Offset will not be committed and the message will be redelivered.",
+                            kafkaEventData.Topic, partition, kafkaEventData.Offset);
+                        break;  // Stop processing remaining events in this partition
+                    }
                 }
             }
         }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Constants.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Constants.cs
@@ -12,7 +12,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         internal const string MyProtobufTopicName = "myProtobufTopic";
         internal const string SchemaRegistryTopicName = "schemaRegistryTopic";
         internal const string SchemaRegistryNoKeyTopicName = "schemaRegistryNoKeyTopic";
+        internal const string AtLeastOnceTopicName = "atLeastOnceTopic";
+        internal const string AtLeastOnceMaxRetriesTopicName = "atLeastOnceMaxRetriesTopic";
         internal const string ConsumerGroupID = "e2e_tests";
+        internal const string AtLeastOnceConsumerGroupID = "at_least_once_e2e";
+        internal const string AtLeastOnceMaxRetriesConsumerGroupID = "at_least_once_maxretries_e2e";
         internal const string SchemaRegistryUrl = "localhost:8081";
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTestFixture.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTestFixture.cs
@@ -38,6 +38,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
         internal TopicSpecification schemaRegistryNoKeyTopic { get; } = new TopicSpecification() { Name = Constants.SchemaRegistryNoKeyTopicName, NumPartitions = 1, ReplicationFactor = 1 };
 
+        internal TopicSpecification AtLeastOnceTopic { get; } = new TopicSpecification() { Name = Constants.AtLeastOnceTopicName, NumPartitions = 1, ReplicationFactor = 1 };
+
+        internal TopicSpecification AtLeastOnceMaxRetriesTopic { get; } = new TopicSpecification() { Name = Constants.AtLeastOnceMaxRetriesTopicName, NumPartitions = 1, ReplicationFactor = 1 };
+
         public KafkaEndToEndTestFixture()
         {
             var config = new ConfigurationBuilder()

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
@@ -976,7 +976,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
         private Task<IHost> StartHostAsync(Type testType, ILoggerProvider customLoggerProvider = null) => StartHostAsync(new[] { testType }, customLoggerProvider);
 
-        private async Task<IHost> StartHostAsync(Type[] testTypes, ILoggerProvider customLoggerProvider = null, Action<IServiceCollection> serviceRegistrationCallback = null)
+        private async Task<IHost> StartHostAsync(Type[] testTypes, ILoggerProvider customLoggerProvider = null, Action<IServiceCollection> serviceRegistrationCallback = null, Action<KafkaOptions> configureKafka = null)
         {
             IHost host = new HostBuilder()
                 .ConfigureWebJobs(builder =>
@@ -987,6 +987,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     .AddKafka(kafkaoption =>
                     {
                         kafkaoption.SessionTimeoutMs = 10000;
+                        configureKafka?.Invoke(kafkaoption);
                     });
                 })
                 .ConfigureAppConfiguration(c =>
@@ -1189,6 +1190,115 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 await Task.Delay(1500);
                 await host.StopAsync();
             }
+        }
+
+        /// <summary>
+        /// Validates at-least-once delivery: when a function fails on the first attempt,
+        /// the message is redelivered and processed successfully on the second attempt.
+        /// CommitOnFailure=false (default) ensures the offset is not committed on failure.
+        /// </summary>
+        [Fact]
+        public async Task AtLeastOnce_SingleTrigger_FailThenSucceed_MessageRedelivered()
+        {
+            const int producedMessagesCount = 3;
+            var messagePrefix = Guid.NewGuid().ToString() + ":";
+
+            var loggerProvider1 = CreateTestLoggerProvider();
+
+            // CommitOnFailure=false is the default, but being explicit for clarity
+            using (var host = await StartHostAsync(
+                new[] { typeof(SingleItem_AtLeastOnce_FailThenSucceed_Trigger), typeof(KafkaOutputFunctions) },
+                loggerProvider1,
+                configureKafka: options =>
+                {
+                    options.CommitOnFailure = false;
+                }))
+            {
+                var jobHost = host.GetJobHost();
+
+                await jobHost.CallOutputTriggerStringAsync(
+                    GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
+                    endToEndTestFixture.AtLeastOnceTopic.Name,
+                    Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefix + x));
+
+                // Wait for all messages to be processed successfully (each message needs 2 attempts)
+                await TestHelpers.Await(() =>
+                {
+                    var successCount = loggerProvider1.GetAllUserLogMessages()
+                        .Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("AtLeastOnce SUCCESS for " + messagePrefix));
+                    return successCount == producedMessagesCount;
+                });
+
+                await Task.Delay(1500);
+                await host.StopAsync();
+            }
+
+            // Verify each message was attempted at least twice (first fail, then succeed)
+            var attemptLogs = loggerProvider1.GetAllUserLogMessages()
+                .Where(p => p.FormattedMessage != null && p.FormattedMessage.Contains("AtLeastOnce attempt"))
+                .Select(p => p.FormattedMessage)
+                .ToList();
+
+            // Should have at least producedMessagesCount * 2 attempt logs (1 fail + 1 success per message)
+            Assert.True(attemptLogs.Count >= producedMessagesCount * 2,
+                $"Expected at least {producedMessagesCount * 2} attempt logs, got {attemptLogs.Count}. Logs: {string.Join("; ", attemptLogs)}");
+        }
+
+        /// <summary>
+        /// Validates maxRetries: when a function always fails, the message is retried up to maxRetries times,
+        /// then the offset is force-committed and the next message is processed.
+        /// Produces 2 messages: the first always fails (should be skipped after maxRetries),
+        /// the second should eventually be processed (also fails, but verifies that processing moves on).
+        /// </summary>
+        [Fact]
+        public async Task AtLeastOnce_SingleTrigger_AlwaysFails_MaxRetriesSkipsMessage()
+        {
+            const int maxRetries = 2;
+            var messagePrefix = Guid.NewGuid().ToString() + ":";
+
+            var loggerProvider1 = CreateTestLoggerProvider();
+
+            using (var host = await StartHostAsync(
+                new[] { typeof(SingleItem_AtLeastOnce_AlwaysFail_Trigger), typeof(KafkaOutputFunctions) },
+                loggerProvider1,
+                configureKafka: options =>
+                {
+                    options.CommitOnFailure = false;
+                    options.MaxRetries = maxRetries;
+                }))
+            {
+                var jobHost = host.GetJobHost();
+
+                // Produce 2 messages
+                await jobHost.CallOutputTriggerStringAsync(
+                    GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
+                    endToEndTestFixture.AtLeastOnceMaxRetriesTopic.Name,
+                    Enumerable.Range(1, 2).Select(x => messagePrefix + x));
+
+                // Wait for the force-commit log that indicates maxRetries was exceeded
+                await TestHelpers.Await(() =>
+                {
+                    var forceCommitLogs = loggerProvider1.GetAllLogMessages()
+                        .Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("force-committed"));
+                    return forceCommitLogs >= 1;
+                });
+
+                await Task.Delay(1500);
+                await host.StopAsync();
+            }
+
+            // Verify that both messages were attempted (proving the first was skipped via force-commit)
+            var message1Attempts = loggerProvider1.GetAllUserLogMessages()
+                .Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefix + "1"));
+            var message2Attempts = loggerProvider1.GetAllUserLogMessages()
+                .Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefix + "2"));
+
+            // Message 1 should have been attempted maxRetries+1 times (initial + retries)
+            // then force-committed, allowing message 2 to be processed
+            Assert.True(message1Attempts >= maxRetries + 1,
+                $"Expected at least {maxRetries + 1} attempts for message 1, got {message1Attempts}");
+            Assert.True(message2Attempts >= 1,
+                $"Expected message 2 to be attempted at least once after message 1 was force-committed, got {message2Attempts}");
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
@@ -1205,7 +1205,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
             var loggerProvider1 = CreateTestLoggerProvider();
 
-            // CommitOnFailure=false is the default, but being explicit for clarity
+            // CommitOnFailure=false enables at-least-once with in-place retry
             using (var host = await StartHostAsync(
                 new[] { typeof(SingleItem_AtLeastOnce_FailThenSucceed_Trigger), typeof(KafkaOutputFunctions) },
                 loggerProvider1,

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
@@ -1194,8 +1194,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
         /// <summary>
         /// Validates at-least-once delivery: when a function fails on the first attempt,
-        /// the message is redelivered and processed successfully on the second attempt.
-        /// CommitOnFailure=false (default) ensures the offset is not committed on failure.
+        /// the message is retried in-place and processed successfully on the second attempt.
+        /// CommitOnFailure=false enables at-least-once with in-place retry.
         /// </summary>
         [Fact]
         public async Task AtLeastOnce_SingleTrigger_FailThenSucceed_MessageRedelivered()

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/TriggerFunctions.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/TriggerFunctions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Emit;
@@ -379,6 +380,48 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 throw new Exception("MyAvro key is null");
             }
             log.BeginScope($"Key: {myKey.ToString()}");
+        }
+    }
+
+    /// <summary>
+    /// Trigger function that fails on the first attempt for each message (tracked by a static counter per message prefix).
+    /// On the second attempt (redelivery), it succeeds. Used to validate at-least-once delivery.
+    /// </summary>
+    internal static class SingleItem_AtLeastOnce_FailThenSucceed_Trigger
+    {
+        private static readonly ConcurrentDictionary<string, int> AttemptCounts = new ConcurrentDictionary<string, int>();
+
+        public static void Trigger(
+            [KafkaTrigger("LocalBroker", Constants.AtLeastOnceTopicName, ConsumerGroup = Constants.AtLeastOnceConsumerGroupID)] KafkaEventData<string> kafkaEvent,
+            ILogger log)
+        {
+            var value = kafkaEvent.Value.ToString();
+            var attempt = AttemptCounts.AddOrUpdate(value, 1, (_, c) => c + 1);
+            log.LogInformation("AtLeastOnce attempt {attempt} for {value}", attempt, value);
+
+            if (attempt == 1)
+            {
+                throw new InvalidOperationException($"Simulated failure on first attempt for: {value}");
+            }
+
+            // Second attempt: succeed
+            log.LogInformation("AtLeastOnce SUCCESS for {value}", value);
+        }
+    }
+
+    /// <summary>
+    /// Trigger function that always fails. Used to validate maxRetries force-commit behavior.
+    /// After maxRetries, the extension should skip the message and process the next one.
+    /// </summary>
+    internal static class SingleItem_AtLeastOnce_AlwaysFail_Trigger
+    {
+        public static void Trigger(
+            [KafkaTrigger("LocalBroker", Constants.AtLeastOnceMaxRetriesTopicName, ConsumerGroup = Constants.AtLeastOnceMaxRetriesConsumerGroupID)] KafkaEventData<string> kafkaEvent,
+            ILogger log)
+        {
+            var value = kafkaEvent.Value.ToString();
+            log.LogInformation("AtLeastOnce_AlwaysFail for {value}", value);
+            throw new InvalidOperationException($"Permanent failure for: {value}");
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
@@ -21,6 +21,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
     /// </summary>
     public class AtLeastOnceDeliveryTest
     {
+        /// <summary>
+        /// Default timeout for all async waits. Long enough for slow CI, short enough to fail fast.
+        /// </summary>
+        private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+
         private ConsumeResult<TKey, TValue> CreateConsumeResult<TKey, TValue>(TValue value, int partition, long offset, string topic = "topic")
         {
             var msg = new Message<TKey, TValue>()
@@ -38,16 +43,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             return res;
         }
 
-        private (Mock<ITriggeredFunctionExecutor> executor, Mock<IConsumer<Null, string>> consumer, ConcurrentQueue<TopicPartitionOffset> committed) CreateMocks()
+        /// <summary>
+        /// Creates mock executor, consumer, and a queue that captures committed offsets.
+        /// The commitSignal is released each time StoreOffset is called.
+        /// </summary>
+        private (Mock<ITriggeredFunctionExecutor> executor, Mock<IConsumer<Null, string>> consumer, ConcurrentQueue<TopicPartitionOffset> committed, SemaphoreSlim commitSignal) CreateMocks()
         {
             var executor = new Mock<ITriggeredFunctionExecutor>();
             var consumer = new Mock<IConsumer<Null, string>>();
             var committed = new ConcurrentQueue<TopicPartitionOffset>();
+            var commitSignal = new SemaphoreSlim(0);
 
             consumer.Setup(x => x.StoreOffset(It.IsNotNull<TopicPartitionOffset>()))
-                .Callback<TopicPartitionOffset>((tpo) => committed.Enqueue(tpo));
+                .Callback<TopicPartitionOffset>((tpo) =>
+                {
+                    committed.Enqueue(tpo);
+                    commitSignal.Release();
+                });
 
-            return (executor, consumer, committed);
+            return (executor, consumer, committed, commitSignal);
         }
 
         private KafkaListenerForTest<Null, string> CreateListener(
@@ -86,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         [Fact]
         public async Task SingleItem_FunctionFails_OffsetNotCommitted()
         {
-            var (executor, consumer, committed) = CreateMocks();
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
 
             consumer.SetupSequence(x => x.Consume(It.IsNotNull<TimeSpan>()))
                 .Returns(CreateConsumeResult<Null, string>("msg1", 0, 0))
@@ -100,14 +114,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var target = CreateListener(executor, consumer, singleDispatch: true);
 
             await target.StartAsync(default);
-            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.True(await executorCalled.WaitAsync(TestTimeout), "Executor should have been called");
 
-            // Give time for commit to _not_ happen
-            await Task.Delay(500);
+            // commitSignal should NOT fire — wait briefly and confirm nothing arrived
+            Assert.False(await commitSignal.WaitAsync(TimeSpan.FromMilliseconds(200)), "Offset should not have been committed on failure");
 
             await target.StopAsync(default);
-
-            // Offset should NOT have been committed
             Assert.Empty(committed);
         }
 
@@ -117,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         [Fact]
         public async Task SingleItem_FunctionFails_StopsPartitionProcessing()
         {
-            var (executor, consumer, committed) = CreateMocks();
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
 
             // 3 events on same partition
             consumer.SetupSequence(x => x.Consume(It.IsNotNull<TimeSpan>()))
@@ -127,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 .Returns((ConsumeResult<Null, string>)null);
 
             var executorCalls = 0;
-            var executorDone = new SemaphoreSlim(0);
+            var executorCalledTwice = new SemaphoreSlim(0);
 
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
                 .Returns<TriggeredFunctionData, CancellationToken>((td, _) =>
@@ -135,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                     var call = Interlocked.Increment(ref executorCalls);
                     if (call >= 2)
                     {
-                        executorDone.Release();
+                        executorCalledTwice.Release();
                     }
 
                     // First message succeeds, second fails
@@ -152,17 +164,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var target = CreateListener(executor, consumer, singleDispatch: true);
 
             await target.StartAsync(default);
-            Assert.True(await executorDone.WaitAsync(TimeSpan.FromSeconds(5)));
 
-            await Task.Delay(500);
+            // Wait for commit of first message (success)
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "First message should have been committed");
+
+            // Wait for executor to be called a second time (failure)
+            Assert.True(await executorCalledTwice.WaitAsync(TestTimeout), "Executor should have been called twice");
+
+            // No more commits should arrive (2nd failed, 3rd not processed)
+            Assert.False(await commitSignal.WaitAsync(TimeSpan.FromMilliseconds(200)), "No more commits should happen after failure");
+
             await target.StopAsync(default);
 
-            // Only the first message's offset should be committed
             Assert.Single(committed);
             Assert.Equal(1, committed.First().Offset);  // offset 0 + 1
-
-            // 3rd message should NOT have been executed (break on failure)
-            Assert.Equal(2, executorCalls);
+            Assert.Equal(2, executorCalls);  // 3rd message NOT executed
         }
 
         // ====================================================================
@@ -171,27 +187,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         [Fact]
         public async Task SingleItem_FunctionFails_CommitOnFailureTrue_OffsetCommitted()
         {
-            var (executor, consumer, committed) = CreateMocks();
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
 
             consumer.SetupSequence(x => x.Consume(It.IsNotNull<TimeSpan>()))
                 .Returns(CreateConsumeResult<Null, string>("msg1", 0, 0))
                 .Returns((ConsumeResult<Null, string>)null);
 
-            var executorCalled = new SemaphoreSlim(0);
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
-                .Callback(() => executorCalled.Release())
                 .ReturnsAsync(new FunctionResult(false));
 
             var options = new KafkaOptions { CommitOnFailure = true };
             var target = CreateListener(executor, consumer, singleDispatch: true, options: options);
 
             await target.StartAsync(default);
-            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
 
-            await Task.Delay(500);
+            // Wait for the commit (should happen despite failure)
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Offset should be committed with CommitOnFailure=true");
+
             await target.StopAsync(default);
 
-            // Offset SHOULD be committed (legacy behavior)
             Assert.Single(committed);
             Assert.Equal(1, committed.First().Offset);
         }
@@ -202,38 +216,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         [Fact]
         public async Task SingleItem_FunctionFails_MaxRetriesExceeded_ForceCommits()
         {
-            var (executor, consumer, committed) = CreateMocks();
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
             var maxRetries = 2;
 
             // Return the same message repeatedly (simulating redelivery)
             consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
                 .Returns(() => CreateConsumeResult<Null, string>("poison", 0, 5));
 
-            var executorCallCount = 0;
-            var forceCommitted = new SemaphoreSlim(0);
-
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
-                .Returns<TriggeredFunctionData, CancellationToken>((td, _) =>
-                {
-                    Interlocked.Increment(ref executorCallCount);
-                    return Task.FromResult(new FunctionResult(false));
-                });
+                .ReturnsAsync(new FunctionResult(false));
 
             var options = new KafkaOptions { MaxRetries = maxRetries };
             var target = CreateListener(executor, consumer, singleDispatch: true, options: options);
 
             await target.StartAsync(default);
 
-            // Wait for enough retries + force-commit
-            // MaxRetries=2 means: 1st try + 2 retries = 3 executions, on 4th the counter exceeds
-            // Actually: HasExceededMaxRetries increments and checks > maxRetries
-            // Call 1: count=1, >2? no. Call 2: count=2, >2? no. Call 3: count=3, >2? yes → force-commit
-            await Task.Delay(3000);
+            // Wait for the force-commit (after maxRetries+1 attempts)
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Should have force-committed the poison message");
 
             await target.StopAsync(default);
 
-            // Should have force-committed after maxRetries+1 attempts
-            Assert.True(committed.Count > 0, "Should have force-committed the poison message");
+            Assert.True(committed.Count > 0);
             Assert.Equal(6, committed.First().Offset);  // offset 5 + 1
         }
 
@@ -243,14 +246,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         [Fact]
         public async Task SingleItem_FunctionFails_UnlimitedRetries_NeverForceCommits()
         {
-            var (executor, consumer, committed) = CreateMocks();
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
 
             consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
                 .Returns(() => CreateConsumeResult<Null, string>("fail", 0, 0));
 
             var executorCallCount = 0;
+            var enoughRetries = new SemaphoreSlim(0);
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
-                .Callback(() => Interlocked.Increment(ref executorCallCount))
+                .Callback(() =>
+                {
+                    if (Interlocked.Increment(ref executorCallCount) >= 10)
+                    {
+                        enoughRetries.Release();
+                    }
+                })
                 .ReturnsAsync(new FunctionResult(false));
 
             var options = new KafkaOptions { MaxRetries = -1 };
@@ -258,15 +268,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             await target.StartAsync(default);
 
-            // Let it retry several times
-            await Task.Delay(2000);
+            // Wait for at least 10 retries
+            Assert.True(await enoughRetries.WaitAsync(TestTimeout), "Should have retried at least 10 times");
 
             await target.StopAsync(default);
 
-            // Should never have committed
+            // Should never have committed despite many retries
             Assert.Empty(committed);
-            // But should have been called multiple times
-            Assert.True(executorCallCount > 3, $"Expected more than 3 retries, got {executorCallCount}");
+            Assert.True(executorCallCount >= 10);
         }
 
         // ====================================================================
@@ -275,26 +284,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         [Fact]
         public async Task SingleItem_FunctionSucceeds_OffsetCommitted()
         {
-            var (executor, consumer, committed) = CreateMocks();
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
 
             consumer.SetupSequence(x => x.Consume(It.IsNotNull<TimeSpan>()))
                 .Returns(CreateConsumeResult<Null, string>("msg1", 0, 0))
                 .Returns((ConsumeResult<Null, string>)null);
 
-            var executorCalled = new SemaphoreSlim(0);
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
-                .Callback(() => executorCalled.Release())
                 .ReturnsAsync(new FunctionResult(true));
 
             var target = CreateListener(executor, consumer, singleDispatch: true);
 
             await target.StartAsync(default);
-            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
 
-            await Task.Delay(500);
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Offset should be committed on success");
+
             await target.StopAsync(default);
 
-            // Offset should be committed
             Assert.Single(committed);
             Assert.Equal(1, committed.First().Offset);
         }
@@ -305,7 +311,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         [Fact]
         public async Task MultiItem_FunctionFails_OffsetNotCommitted()
         {
-            var (executor, consumer, committed) = CreateMocks();
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
 
             var offset = 0L;
             consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
@@ -316,6 +322,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                         offset++;
                         return CreateConsumeResult<Null, string>(offset.ToString(), 0, offset);
                     }
+
                     return null;
                 });
 
@@ -327,12 +334,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var target = CreateListener(executor, consumer, singleDispatch: false);
 
             await target.StartAsync(default);
-            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
+            Assert.True(await executorCalled.WaitAsync(TestTimeout), "Executor should have been called");
 
-            await Task.Delay(500);
+            // commitSignal should NOT fire
+            Assert.False(await commitSignal.WaitAsync(TimeSpan.FromMilliseconds(200)), "Offset should not have been committed on failure");
+
             await target.StopAsync(default);
-
-            // Offset should NOT have been committed
             Assert.Empty(committed);
         }
 
@@ -342,7 +349,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         [Fact]
         public async Task MultiItem_FunctionFails_CommitOnFailureTrue_OffsetCommitted()
         {
-            var (executor, consumer, committed) = CreateMocks();
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
 
             var offset = 0L;
             consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
@@ -353,43 +360,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                         offset++;
                         return CreateConsumeResult<Null, string>(offset.ToString(), 0, offset);
                     }
+
                     return null;
                 });
 
-            var executorCalled = new SemaphoreSlim(0);
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
-                .Callback(() => executorCalled.Release())
                 .ReturnsAsync(new FunctionResult(false));
 
             var options = new KafkaOptions { CommitOnFailure = true };
             var target = CreateListener(executor, consumer, singleDispatch: false, options: options);
 
             await target.StartAsync(default);
-            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
 
-            await Task.Delay(500);
+            // Wait for the commit (should happen despite failure)
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Offset should be committed with CommitOnFailure=true");
+
             await target.StopAsync(default);
-
-            // Offset SHOULD be committed (legacy behavior)
             Assert.NotEmpty(committed);
         }
 
         // ====================================================================
-        // Batch-dispatch: MaxRetries exceeded → force-commit 
+        // Batch-dispatch: MaxRetries exceeded → force-commit
         // ====================================================================
         [Fact]
         public async Task MultiItem_FunctionFails_MaxRetriesExceeded_ForceCommits()
         {
-            var (executor, consumer, committed) = CreateMocks();
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
             var maxRetries = 2;
 
             // Always return the same batch
             consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
                 .Returns(() => CreateConsumeResult<Null, string>("batch-poison", 0, 10));
 
-            var executorCallCount = 0;
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
-                .Callback(() => Interlocked.Increment(ref executorCallCount))
                 .ReturnsAsync(new FunctionResult(false));
 
             var options = new KafkaOptions { MaxRetries = maxRetries };
@@ -397,13 +400,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             await target.StartAsync(default);
 
-            // Wait for retries + force-commit
-            await Task.Delay(3000);
+            // Wait for the force-commit
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Should have force-committed the batch after max retries");
 
             await target.StopAsync(default);
-
-            // Should have force-committed
-            Assert.True(committed.Count > 0, "Should have force-committed the batch after max retries");
+            Assert.True(committed.Count > 0);
         }
 
         // ====================================================================
@@ -412,7 +413,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         [Fact]
         public async Task MultiItem_FunctionSucceeds_OffsetCommitted()
         {
-            var (executor, consumer, committed) = CreateMocks();
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
 
             var offset = 0L;
             consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
@@ -423,23 +424,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                         offset++;
                         return CreateConsumeResult<Null, string>(offset.ToString(), 0, offset);
                     }
+
                     return null;
                 });
 
-            var executorCalled = new SemaphoreSlim(0);
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
-                .Callback(() => executorCalled.Release())
                 .ReturnsAsync(new FunctionResult(true));
 
             var target = CreateListener(executor, consumer, singleDispatch: false);
 
             await target.StartAsync(default);
-            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
 
-            await Task.Delay(500);
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Offset should be committed on success");
+
             await target.StopAsync(default);
-
-            // Offset should be committed
             Assert.NotEmpty(committed);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
@@ -1,0 +1,482 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Confluent.Kafka;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    /// <summary>
+    /// Tests for at-least-once delivery behavior (Issue #614).
+    /// Validates that offset commits are skipped on function failure,
+    /// CommitOnFailure opt-in, and maxRetries poison message protection.
+    /// </summary>
+    public class AtLeastOnceDeliveryTest
+    {
+        private ConsumeResult<TKey, TValue> CreateConsumeResult<TKey, TValue>(TValue value, int partition, long offset, string topic = "topic")
+        {
+            var msg = new Message<TKey, TValue>()
+            {
+                Value = value,
+                Timestamp = Timestamp.Default,
+            };
+
+            var res = new ConsumeResult<TKey, TValue>();
+            res.Message = msg;
+            res.Topic = topic;
+            res.Partition = partition;
+            res.Offset = offset;
+
+            return res;
+        }
+
+        private (Mock<ITriggeredFunctionExecutor> executor, Mock<IConsumer<Null, string>> consumer, ConcurrentQueue<TopicPartitionOffset> committed) CreateMocks()
+        {
+            var executor = new Mock<ITriggeredFunctionExecutor>();
+            var consumer = new Mock<IConsumer<Null, string>>();
+            var committed = new ConcurrentQueue<TopicPartitionOffset>();
+
+            consumer.Setup(x => x.StoreOffset(It.IsNotNull<TopicPartitionOffset>()))
+                .Callback<TopicPartitionOffset>((tpo) => committed.Enqueue(tpo));
+
+            return (executor, consumer, committed);
+        }
+
+        private KafkaListenerForTest<Null, string> CreateListener(
+            Mock<ITriggeredFunctionExecutor> executor,
+            Mock<IConsumer<Null, string>> consumer,
+            bool singleDispatch,
+            KafkaOptions options = null)
+        {
+            options = options ?? new KafkaOptions();
+            var listenerConfig = new KafkaListenerConfiguration()
+            {
+                BrokerList = "testBroker",
+                Topic = "topic",
+                ConsumerGroup = "group1",
+            };
+
+            var target = new KafkaListenerForTest<Null, string>(
+                executor.Object,
+                singleDispatch,
+                options,
+                listenerConfig,
+                requiresKey: true,
+                valueDeserializer: null,
+                keyDeserializer: null,
+                NullLogger.Instance,
+                functionId: "testId",
+                drainModeManager: null);
+
+            target.SetConsumer(consumer.Object);
+            return target;
+        }
+
+        // ====================================================================
+        // Single-dispatch: Function fails → offset NOT committed
+        // ====================================================================
+        [Fact]
+        public async Task SingleItem_FunctionFails_OffsetNotCommitted()
+        {
+            var (executor, consumer, committed) = CreateMocks();
+
+            consumer.SetupSequence(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(CreateConsumeResult<Null, string>("msg1", 0, 0))
+                .Returns((ConsumeResult<Null, string>)null);
+
+            var executorCalled = new SemaphoreSlim(0);
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Callback(() => executorCalled.Release())
+                .ReturnsAsync(new FunctionResult(false));
+
+            var target = CreateListener(executor, consumer, singleDispatch: true);
+
+            await target.StartAsync(default);
+            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
+
+            // Give time for commit to _not_ happen
+            await Task.Delay(500);
+
+            await target.StopAsync(default);
+
+            // Offset should NOT have been committed
+            Assert.Empty(committed);
+        }
+
+        // ====================================================================
+        // Single-dispatch: Function fails → stops processing remaining events
+        // ====================================================================
+        [Fact]
+        public async Task SingleItem_FunctionFails_StopsPartitionProcessing()
+        {
+            var (executor, consumer, committed) = CreateMocks();
+
+            // 3 events on same partition
+            consumer.SetupSequence(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(CreateConsumeResult<Null, string>("msg1", 0, 0))
+                .Returns(CreateConsumeResult<Null, string>("msg2", 0, 1))
+                .Returns(CreateConsumeResult<Null, string>("msg3", 0, 2))
+                .Returns((ConsumeResult<Null, string>)null);
+
+            var executorCalls = 0;
+            var executorDone = new SemaphoreSlim(0);
+
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Returns<TriggeredFunctionData, CancellationToken>((td, _) =>
+                {
+                    var call = Interlocked.Increment(ref executorCalls);
+                    if (call >= 2)
+                    {
+                        executorDone.Release();
+                    }
+
+                    // First message succeeds, second fails
+                    if (call == 1)
+                    {
+                        return Task.FromResult(new FunctionResult(true));
+                    }
+                    else
+                    {
+                        return Task.FromResult(new FunctionResult(false));
+                    }
+                });
+
+            var target = CreateListener(executor, consumer, singleDispatch: true);
+
+            await target.StartAsync(default);
+            Assert.True(await executorDone.WaitAsync(TimeSpan.FromSeconds(5)));
+
+            await Task.Delay(500);
+            await target.StopAsync(default);
+
+            // Only the first message's offset should be committed
+            Assert.Single(committed);
+            Assert.Equal(1, committed.First().Offset);  // offset 0 + 1
+
+            // 3rd message should NOT have been executed (break on failure)
+            Assert.Equal(2, executorCalls);
+        }
+
+        // ====================================================================
+        // Single-dispatch: CommitOnFailure=true → offset committed on failure
+        // ====================================================================
+        [Fact]
+        public async Task SingleItem_FunctionFails_CommitOnFailureTrue_OffsetCommitted()
+        {
+            var (executor, consumer, committed) = CreateMocks();
+
+            consumer.SetupSequence(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(CreateConsumeResult<Null, string>("msg1", 0, 0))
+                .Returns((ConsumeResult<Null, string>)null);
+
+            var executorCalled = new SemaphoreSlim(0);
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Callback(() => executorCalled.Release())
+                .ReturnsAsync(new FunctionResult(false));
+
+            var options = new KafkaOptions { CommitOnFailure = true };
+            var target = CreateListener(executor, consumer, singleDispatch: true, options: options);
+
+            await target.StartAsync(default);
+            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
+
+            await Task.Delay(500);
+            await target.StopAsync(default);
+
+            // Offset SHOULD be committed (legacy behavior)
+            Assert.Single(committed);
+            Assert.Equal(1, committed.First().Offset);
+        }
+
+        // ====================================================================
+        // Single-dispatch: MaxRetries exceeded → force-commit
+        // ====================================================================
+        [Fact]
+        public async Task SingleItem_FunctionFails_MaxRetriesExceeded_ForceCommits()
+        {
+            var (executor, consumer, committed) = CreateMocks();
+            var maxRetries = 2;
+
+            // Return the same message repeatedly (simulating redelivery)
+            consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(() => CreateConsumeResult<Null, string>("poison", 0, 5));
+
+            var executorCallCount = 0;
+            var forceCommitted = new SemaphoreSlim(0);
+
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Returns<TriggeredFunctionData, CancellationToken>((td, _) =>
+                {
+                    Interlocked.Increment(ref executorCallCount);
+                    return Task.FromResult(new FunctionResult(false));
+                });
+
+            var options = new KafkaOptions { MaxRetries = maxRetries };
+            var target = CreateListener(executor, consumer, singleDispatch: true, options: options);
+
+            await target.StartAsync(default);
+
+            // Wait for enough retries + force-commit
+            // MaxRetries=2 means: 1st try + 2 retries = 3 executions, on 4th the counter exceeds
+            // Actually: HasExceededMaxRetries increments and checks > maxRetries
+            // Call 1: count=1, >2? no. Call 2: count=2, >2? no. Call 3: count=3, >2? yes → force-commit
+            await Task.Delay(3000);
+
+            await target.StopAsync(default);
+
+            // Should have force-committed after maxRetries+1 attempts
+            Assert.True(committed.Count > 0, "Should have force-committed the poison message");
+            Assert.Equal(6, committed.First().Offset);  // offset 5 + 1
+        }
+
+        // ====================================================================
+        // Single-dispatch: MaxRetries=-1 (unlimited) → never force-commits
+        // ====================================================================
+        [Fact]
+        public async Task SingleItem_FunctionFails_UnlimitedRetries_NeverForceCommits()
+        {
+            var (executor, consumer, committed) = CreateMocks();
+
+            consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(() => CreateConsumeResult<Null, string>("fail", 0, 0));
+
+            var executorCallCount = 0;
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Callback(() => Interlocked.Increment(ref executorCallCount))
+                .ReturnsAsync(new FunctionResult(false));
+
+            var options = new KafkaOptions { MaxRetries = -1 };
+            var target = CreateListener(executor, consumer, singleDispatch: true, options: options);
+
+            await target.StartAsync(default);
+
+            // Let it retry several times
+            await Task.Delay(2000);
+
+            await target.StopAsync(default);
+
+            // Should never have committed
+            Assert.Empty(committed);
+            // But should have been called multiple times
+            Assert.True(executorCallCount > 3, $"Expected more than 3 retries, got {executorCallCount}");
+        }
+
+        // ====================================================================
+        // Single-dispatch: Function succeeds → offset committed (regression)
+        // ====================================================================
+        [Fact]
+        public async Task SingleItem_FunctionSucceeds_OffsetCommitted()
+        {
+            var (executor, consumer, committed) = CreateMocks();
+
+            consumer.SetupSequence(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(CreateConsumeResult<Null, string>("msg1", 0, 0))
+                .Returns((ConsumeResult<Null, string>)null);
+
+            var executorCalled = new SemaphoreSlim(0);
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Callback(() => executorCalled.Release())
+                .ReturnsAsync(new FunctionResult(true));
+
+            var target = CreateListener(executor, consumer, singleDispatch: true);
+
+            await target.StartAsync(default);
+            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
+
+            await Task.Delay(500);
+            await target.StopAsync(default);
+
+            // Offset should be committed
+            Assert.Single(committed);
+            Assert.Equal(1, committed.First().Offset);
+        }
+
+        // ====================================================================
+        // Batch-dispatch: Function fails → offset NOT committed
+        // ====================================================================
+        [Fact]
+        public async Task MultiItem_FunctionFails_OffsetNotCommitted()
+        {
+            var (executor, consumer, committed) = CreateMocks();
+
+            var offset = 0L;
+            consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(() =>
+                {
+                    if (offset < 5)
+                    {
+                        offset++;
+                        return CreateConsumeResult<Null, string>(offset.ToString(), 0, offset);
+                    }
+                    return null;
+                });
+
+            var executorCalled = new SemaphoreSlim(0);
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Callback(() => executorCalled.Release())
+                .ReturnsAsync(new FunctionResult(false));
+
+            var target = CreateListener(executor, consumer, singleDispatch: false);
+
+            await target.StartAsync(default);
+            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
+
+            await Task.Delay(500);
+            await target.StopAsync(default);
+
+            // Offset should NOT have been committed
+            Assert.Empty(committed);
+        }
+
+        // ====================================================================
+        // Batch-dispatch: CommitOnFailure=true → offset committed on failure
+        // ====================================================================
+        [Fact]
+        public async Task MultiItem_FunctionFails_CommitOnFailureTrue_OffsetCommitted()
+        {
+            var (executor, consumer, committed) = CreateMocks();
+
+            var offset = 0L;
+            consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(() =>
+                {
+                    if (offset < 3)
+                    {
+                        offset++;
+                        return CreateConsumeResult<Null, string>(offset.ToString(), 0, offset);
+                    }
+                    return null;
+                });
+
+            var executorCalled = new SemaphoreSlim(0);
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Callback(() => executorCalled.Release())
+                .ReturnsAsync(new FunctionResult(false));
+
+            var options = new KafkaOptions { CommitOnFailure = true };
+            var target = CreateListener(executor, consumer, singleDispatch: false, options: options);
+
+            await target.StartAsync(default);
+            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
+
+            await Task.Delay(500);
+            await target.StopAsync(default);
+
+            // Offset SHOULD be committed (legacy behavior)
+            Assert.NotEmpty(committed);
+        }
+
+        // ====================================================================
+        // Batch-dispatch: MaxRetries exceeded → force-commit 
+        // ====================================================================
+        [Fact]
+        public async Task MultiItem_FunctionFails_MaxRetriesExceeded_ForceCommits()
+        {
+            var (executor, consumer, committed) = CreateMocks();
+            var maxRetries = 2;
+
+            // Always return the same batch
+            consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(() => CreateConsumeResult<Null, string>("batch-poison", 0, 10));
+
+            var executorCallCount = 0;
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Callback(() => Interlocked.Increment(ref executorCallCount))
+                .ReturnsAsync(new FunctionResult(false));
+
+            var options = new KafkaOptions { MaxRetries = maxRetries };
+            var target = CreateListener(executor, consumer, singleDispatch: false, options: options);
+
+            await target.StartAsync(default);
+
+            // Wait for retries + force-commit
+            await Task.Delay(3000);
+
+            await target.StopAsync(default);
+
+            // Should have force-committed
+            Assert.True(committed.Count > 0, "Should have force-committed the batch after max retries");
+        }
+
+        // ====================================================================
+        // Batch-dispatch: Function succeeds → offset committed (regression)
+        // ====================================================================
+        [Fact]
+        public async Task MultiItem_FunctionSucceeds_OffsetCommitted()
+        {
+            var (executor, consumer, committed) = CreateMocks();
+
+            var offset = 0L;
+            consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(() =>
+                {
+                    if (offset < 3)
+                    {
+                        offset++;
+                        return CreateConsumeResult<Null, string>(offset.ToString(), 0, offset);
+                    }
+                    return null;
+                });
+
+            var executorCalled = new SemaphoreSlim(0);
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Callback(() => executorCalled.Release())
+                .ReturnsAsync(new FunctionResult(true));
+
+            var target = CreateListener(executor, consumer, singleDispatch: false);
+
+            await target.StartAsync(default);
+            Assert.True(await executorCalled.WaitAsync(TimeSpan.FromSeconds(5)));
+
+            await Task.Delay(500);
+            await target.StopAsync(default);
+
+            // Offset should be committed
+            Assert.NotEmpty(committed);
+        }
+
+        // ====================================================================
+        // KafkaOptions: MaxRetries validation
+        // ====================================================================
+        [Fact]
+        public void KafkaOptions_MaxRetries_RejectsInvalidValues()
+        {
+            var options = new KafkaOptions();
+
+            // -1 is valid (unlimited)
+            options.MaxRetries = -1;
+            Assert.Equal(-1, options.MaxRetries);
+
+            // 0 is valid (no retries)
+            options.MaxRetries = 0;
+            Assert.Equal(0, options.MaxRetries);
+
+            // Positive values are valid
+            options.MaxRetries = 10;
+            Assert.Equal(10, options.MaxRetries);
+
+            // -2 is invalid
+            Assert.Throws<InvalidOperationException>(() => options.MaxRetries = -2);
+        }
+
+        // ====================================================================
+        // KafkaOptions: Default values
+        // ====================================================================
+        [Fact]
+        public void KafkaOptions_Defaults_AreCorrect()
+        {
+            var options = new KafkaOptions();
+
+            Assert.False(options.CommitOnFailure);
+            Assert.Equal(5, options.MaxRetries);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
@@ -411,6 +411,56 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         // ====================================================================
+        // Batch-dispatch: Function fails then succeeds on retry (CommitOnFailure=false)
+        // ====================================================================
+        [Fact]
+        public async Task MultiItem_FunctionFails_RetriesInPlaceThenSucceeds()
+        {
+            var (executor, consumer, committed, commitSignal) = CreateMocks();
+
+            var offset = 0L;
+            consumer.Setup(x => x.Consume(It.IsNotNull<TimeSpan>()))
+                .Returns(() =>
+                {
+                    if (offset < 3)
+                    {
+                        offset++;
+                        return CreateConsumeResult<Null, string>(offset.ToString(), 0, offset);
+                    }
+
+                    return null;
+                });
+
+            var callCount = 0;
+            executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Returns<TriggeredFunctionData, CancellationToken>((td, _) =>
+                {
+                    var c = Interlocked.Increment(ref callCount);
+                    // First execution fails, second (retry) succeeds
+                    if (c == 1)
+                    {
+                        return Task.FromResult(new FunctionResult(false));
+                    }
+
+                    return Task.FromResult(new FunctionResult(true));
+                });
+
+            var options = new KafkaOptions { CommitOnFailure = false };
+            var target = CreateListener(executor, consumer, singleDispatch: false, options: options);
+
+            await target.StartAsync(default);
+
+            // Wait for commit (retry succeeds on 2nd attempt)
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Should commit after successful batch retry");
+
+            await target.StopAsync(default);
+
+            Assert.NotEmpty(committed);
+            // Should have been called at least 2 times (1 fail + 1 success)
+            Assert.True(callCount >= 2, $"Expected at least 2 calls, got {callCount}");
+        }
+
+        // ====================================================================
         // Batch-dispatch: Function succeeds → offset committed (regression)
         // ====================================================================
         [Fact]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         // ====================================================================
-        // Single-dispatch: Function fails → offset NOT committed
+        // Single-dispatch: Function fails → offset NOT committed (CommitOnFailure=false)
         // ====================================================================
         [Fact]
         public async Task SingleItem_FunctionFails_OffsetNotCommitted()
@@ -106,28 +106,41 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 .Returns(CreateConsumeResult<Null, string>("msg1", 0, 0))
                 .Returns((ConsumeResult<Null, string>)null);
 
-            var executorCalled = new SemaphoreSlim(0);
+            // Function fails, then succeeds (in-place retry)
+            var callCount = 0;
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
-                .Callback(() => executorCalled.Release())
-                .ReturnsAsync(new FunctionResult(false));
+                .Returns<TriggeredFunctionData, CancellationToken>((td, _) =>
+                {
+                    var c = Interlocked.Increment(ref callCount);
+                    if (c == 1)
+                    {
+                        return Task.FromResult(new FunctionResult(false));
+                    }
 
-            var target = CreateListener(executor, consumer, singleDispatch: true);
+                    return Task.FromResult(new FunctionResult(true));
+                });
+
+            var options = new KafkaOptions { CommitOnFailure = false };
+            var target = CreateListener(executor, consumer, singleDispatch: true, options: options);
 
             await target.StartAsync(default);
-            Assert.True(await executorCalled.WaitAsync(TestTimeout), "Executor should have been called");
 
-            // commitSignal should NOT fire — wait briefly and confirm nothing arrived
-            Assert.False(await commitSignal.WaitAsync(TimeSpan.FromMilliseconds(200)), "Offset should not have been committed on failure");
+            // Wait for commit (retry succeeds on 2nd attempt)
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Should commit after successful retry");
 
             await target.StopAsync(default);
-            Assert.Empty(committed);
+
+            // Should have been called at least 2 times (1 fail + 1 success)
+            Assert.True(callCount >= 2, $"Expected at least 2 calls, got {callCount}");
+            Assert.Single(committed);
+            Assert.Equal(1, committed.First().Offset);
         }
 
         // ====================================================================
-        // Single-dispatch: Function fails → stops processing remaining events
+        // Single-dispatch: Function fails → retries in-place then succeeds
         // ====================================================================
         [Fact]
-        public async Task SingleItem_FunctionFails_StopsPartitionProcessing()
+        public async Task SingleItem_FunctionFails_RetriesInPlaceThenSucceeds()
         {
             var (executor, consumer, committed, commitSignal) = CreateMocks();
 
@@ -139,46 +152,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 .Returns((ConsumeResult<Null, string>)null);
 
             var executorCalls = 0;
-            var executorCalledTwice = new SemaphoreSlim(0);
 
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
                 .Returns<TriggeredFunctionData, CancellationToken>((td, _) =>
                 {
                     var call = Interlocked.Increment(ref executorCalls);
-                    if (call >= 2)
-                    {
-                        executorCalledTwice.Release();
-                    }
-
-                    // First message succeeds, second fails
+                    // msg1: call 1 fails, call 2 succeeds
+                    // msg2: call 3 succeeds
+                    // msg3: call 4 succeeds
                     if (call == 1)
-                    {
-                        return Task.FromResult(new FunctionResult(true));
-                    }
-                    else
                     {
                         return Task.FromResult(new FunctionResult(false));
                     }
+
+                    return Task.FromResult(new FunctionResult(true));
                 });
 
-            var target = CreateListener(executor, consumer, singleDispatch: true);
+            var options = new KafkaOptions { CommitOnFailure = false };
+            var target = CreateListener(executor, consumer, singleDispatch: true, options: options);
 
             await target.StartAsync(default);
 
-            // Wait for commit of first message (success)
-            Assert.True(await commitSignal.WaitAsync(TestTimeout), "First message should have been committed");
-
-            // Wait for executor to be called a second time (failure)
-            Assert.True(await executorCalledTwice.WaitAsync(TestTimeout), "Executor should have been called twice");
-
-            // No more commits should arrive (2nd failed, 3rd not processed)
-            Assert.False(await commitSignal.WaitAsync(TimeSpan.FromMilliseconds(200)), "No more commits should happen after failure");
+            // Wait for all 3 messages to be committed (msg1 retried, msg2 and msg3 succeed directly)
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "First commit");
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Second commit");
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Third commit");
 
             await target.StopAsync(default);
 
-            Assert.Single(committed);
-            Assert.Equal(1, committed.First().Offset);  // offset 0 + 1
-            Assert.Equal(2, executorCalls);  // 3rd message NOT executed
+            // All 3 messages committed, msg1 took 2 tries
+            Assert.Equal(3, committed.Count);
+            Assert.Equal(4, executorCalls);  // 1 fail + 3 success
         }
 
         // ====================================================================
@@ -211,7 +215,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         // ====================================================================
-        // Single-dispatch: MaxRetries exceeded → force-commit
+        // Single-dispatch: MaxRetries exceeded → force-commit (CommitOnFailure=false)
         // ====================================================================
         [Fact]
         public async Task SingleItem_FunctionFails_MaxRetriesExceeded_ForceCommits()
@@ -226,12 +230,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new FunctionResult(false));
 
-            var options = new KafkaOptions { MaxRetries = maxRetries };
+            var options = new KafkaOptions { CommitOnFailure = false, MaxRetries = maxRetries };
             var target = CreateListener(executor, consumer, singleDispatch: true, options: options);
 
             await target.StartAsync(default);
 
-            // Wait for the force-commit (after maxRetries+1 attempts)
+            // Wait for the force-commit (after maxRetries+1 attempts via in-place retry)
             Assert.True(await commitSignal.WaitAsync(TestTimeout), "Should have force-committed the poison message");
 
             await target.StopAsync(default);
@@ -241,7 +245,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         // ====================================================================
-        // Single-dispatch: MaxRetries=-1 (unlimited) → never force-commits
+        // Single-dispatch: MaxRetries=-1 (unlimited) → keeps retrying (CommitOnFailure=false)
         // ====================================================================
         [Fact]
         public async Task SingleItem_FunctionFails_UnlimitedRetries_NeverForceCommits()
@@ -263,7 +267,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 })
                 .ReturnsAsync(new FunctionResult(false));
 
-            var options = new KafkaOptions { MaxRetries = -1 };
+            var options = new KafkaOptions { CommitOnFailure = false, MaxRetries = -1 };
             var target = CreateListener(executor, consumer, singleDispatch: true, options: options);
 
             await target.StartAsync(default);
@@ -306,7 +310,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         // ====================================================================
-        // Batch-dispatch: Function fails → offset NOT committed
+        // Batch-dispatch: Function fails → offset NOT committed (CommitOnFailure=false, retries until max)
         // ====================================================================
         [Fact]
         public async Task MultiItem_FunctionFails_OffsetNotCommitted()
@@ -326,21 +330,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                     return null;
                 });
 
-            var executorCalled = new SemaphoreSlim(0);
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
-                .Callback(() => executorCalled.Release())
                 .ReturnsAsync(new FunctionResult(false));
 
-            var target = CreateListener(executor, consumer, singleDispatch: false);
+            // CommitOnFailure=false with maxRetries: eventually force-commits
+            var options = new KafkaOptions { CommitOnFailure = false, MaxRetries = 2 };
+            var target = CreateListener(executor, consumer, singleDispatch: false, options: options);
 
             await target.StartAsync(default);
-            Assert.True(await executorCalled.WaitAsync(TestTimeout), "Executor should have been called");
 
-            // commitSignal should NOT fire
-            Assert.False(await commitSignal.WaitAsync(TimeSpan.FromMilliseconds(200)), "Offset should not have been committed on failure");
+            // Should eventually force-commit after max retries
+            Assert.True(await commitSignal.WaitAsync(TestTimeout), "Should force-commit after max retries");
 
             await target.StopAsync(default);
-            Assert.Empty(committed);
+            Assert.NotEmpty(committed);
         }
 
         // ====================================================================
@@ -380,7 +383,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         // ====================================================================
-        // Batch-dispatch: MaxRetries exceeded → force-commit
+        // Batch-dispatch: MaxRetries exceeded → force-commit (CommitOnFailure=false)
         // ====================================================================
         [Fact]
         public async Task MultiItem_FunctionFails_MaxRetriesExceeded_ForceCommits()
@@ -395,7 +398,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             executor.Setup(x => x.TryExecuteAsync(It.IsNotNull<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new FunctionResult(false));
 
-            var options = new KafkaOptions { MaxRetries = maxRetries };
+            var options = new KafkaOptions { CommitOnFailure = false, MaxRetries = maxRetries };
             var target = CreateListener(executor, consumer, singleDispatch: false, options: options);
 
             await target.StartAsync(default);
@@ -473,7 +476,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         {
             var options = new KafkaOptions();
 
-            Assert.False(options.CommitOnFailure);
+            Assert.True(options.CommitOnFailure);
             Assert.Equal(5, options.MaxRetries);
         }
     }


### PR DESCRIPTION
## Summary

Fixes #614 — Adds opt-in at-least-once delivery support for the Kafka trigger via `commitOnFailure: false` in host.json.

**No breaking changes** — the default behavior is preserved (at-most-once, consistent with EventHubs trigger).

## Changes

### New Configuration Options (host.json)

~~~json
{
  "extensions": {
    "kafka": {
      "commitOnFailure": true,   // default: true (at-most-once, existing behavior)
      "maxRetries": 5            // default: 5 (-1 for unlimited)
    }
  }
}
~~~

| Option | Default | Description |
|--------|---------|-------------|
| commitOnFailure | true | When true (default), offsets are always committed regardless of function result. When false, failed messages are retried in-place. |
| maxRetries | 5 | Max in-place retry attempts before force-committing a poison message. Only applies when commitOnFailure is false. -1 for unlimited. |

### Behavior Matrix

| Scenario | commitOnFailure | Offset committed? | Description |
|----------|----------------|-------------------|-------------|
| Function succeeds | true (default) | Yes | Normal flow |
| Function fails | true (default) | Yes | Existing at-most-once behavior preserved |
| Function fails (retry < max) | false | No (retrying) | In-place retry |
| Function fails (retry >= max) | false | Yes (force) | Poison message skipped with Error log |

### Production Code (5 files)

- **KafkaOptions.cs** — Added CommitOnFailure (default: true) and MaxRetries (default: 5) properties
- **FunctionExecutorBase.cs** — Added KafkaOptions parameter, retry tracking via ConcurrentDictionary, IncrementRetryAndCheckExceeded / ClearRetryCounter helpers
- **SingleItemFunctionExecutor.cs** — In-place retry loop: while loop retries same message until success or maxRetries exceeded
- **MultipleItemFunctionExecutor.cs** — In-place retry loop: re-executes same batch until success or maxRetries exceeded
- **KafkaListener.cs** — Pass options to executor constructors

### Tests

**Unit tests** (12 new tests in AtLeastOnceDeliveryTest.cs):
- Single/Batch dispatch: success commits, failure retries, CommitOnFailure=true commits on failure, MaxRetries force-commits, unlimited retries, KafkaOptions validation

**E2E tests** (2 new tests):
- AtLeastOnce_SingleTrigger_FailThenSucceed_MessageRedelivered — validates in-place retry on failure then success
- AtLeastOnce_SingleTrigger_AlwaysFails_MaxRetriesSkipsMessage — validates force-commit after maxRetries

All 203+ unit tests pass with zero regressions.

## Design Decisions

1. **CommitOnFailure default is true** — Preserves existing at-most-once behavior, consistent with EventHubs trigger ("Functions avoids deadlocks by always advancing the stream's pointer, regardless of success or failure"). No breaking change.
2. **In-place retry instead of break** — Kafka Consumer.Consume() advances internal position regardless of StoreOffset(). Break would skip failed messages permanently. In-place while loop retries the same message/batch immediately.
3. **logger field changed from private to protected** — Required for subclass logging in failure paths.
4. **No built-in DLQ** — Customers implement their own dead-letter handling in function code. See design comment on #614 for the customer-owned DLQ pattern.

## Related

- #614 — Issue tracking this feature
- Comment by @daankets on #612 — Original request for failure handling
- EventHubs reliable event processing: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reliable-event-processing
