### PR TITLE
feat: Add KafkaRecord Protobuf serialization for isolated worker - Phase 2a

### DIFF
--- a/docs/KafkaRecord-Design.md
+++ b/docs/KafkaRecord-Design.md
@@ -1,0 +1,192 @@
+# KafkaRecord Binding — Design & Architecture
+
+> **Status**: Phase 2 of [#612](https://github.com/Azure/azure-functions-kafka-extension/issues/612)
+> **Scope**: .NET Isolated Worker (Phase 2); cross-language support planned (Phase 4+)
+
+## Overview
+
+`KafkaRecord` is a new binding type that gives Azure Functions users access to the complete Apache Kafka record metadata — topic, partition, offset, key (raw bytes), value (raw bytes), headers, timestamp, and leader epoch — without coupling to the Confluent.Kafka library.
+
+Users opt in by changing their function parameter type. Existing bindings (`string`, `byte[]`, `KafkaEventData<T>`) are completely unaffected.
+
+```csharp
+// Existing (unchanged)
+[Function("StringTrigger")]
+public void Run([KafkaTrigger("brokers", "topic", ConsumerGroup = "group")] string message) { }
+
+// NEW: Full record metadata
+[Function("RecordTrigger")]
+public void Run([KafkaTrigger("brokers", "topic", ConsumerGroup = "group")] KafkaRecord record)
+{
+    string key = Encoding.UTF8.GetString(record.Key);
+    var value = JsonSerializer.Deserialize<MyEvent>(record.Value);
+    Console.WriteLine($"Topic={record.Topic} Partition={record.Partition} Offset={record.Offset}");
+
+    foreach (var header in record.Headers)
+        Console.WriteLine($"  {header.Key} = {header.GetValueAsString()}");
+}
+
+// NEW: Batch mode
+[Function("BatchTrigger")]
+public void Run(
+    [KafkaTrigger("brokers", "topic", ConsumerGroup = "group", IsBatched = true)]
+    KafkaRecord[] records) { }
+```
+
+---
+
+## Design Rationale
+
+### Why not expose `ConsumeResult<TKey, TValue>` directly?
+
+The Confluent.Kafka `ConsumeResult<TKey, TValue>` type:
+- Has no public constructor — cannot be reconstructed from serialized bytes across the gRPC process boundary
+- Represents a **consumer state** (includes `IsPartitionEOF`), not a pure Kafka record
+- Uses generics that don't support `TopicRecordName` strategy (multiple schemas per topic)
+- Couples users to the Confluent.Kafka library version shipped with the extension
+
+### The `KafkaRecord` approach
+
+Based on customer feedback ([#612 discussion](https://github.com/Azure/azure-functions-kafka-extension/issues/612)):
+
+| Design Decision | Rationale |
+|----------------|-----------|
+| **No generics** — Key and Value are `byte[]` | User controls deserialization; supports any schema strategy |
+| **Apache Kafka spec-aligned** | Fields match the Kafka protocol record definition |
+| **`IsPartitionEOF` excluded** | Consumer state, not record metadata |
+| **Protobuf serialization** | Zero Base64 overhead for binary key/value transport |
+| **Opt-in via parameter type** | No configuration changes; existing code unaffected |
+
+---
+
+## Architecture
+
+### Data Flow
+
+```
+Host Process                                    Worker Process
+┌─────────────────────────────┐                ┌─────────────────────────────┐
+│ KafkaListener               │                │ KafkaRecordConverter        │
+│  │                          │                │  (IInputConverter)          │
+│  ▼                          │                │  │                          │
+│ ConsumeResult<TKey,TValue>  │                │  ▼                          │
+│  │                          │                │ KafkaRecordProto            │
+│  ▼                          │    gRPC        │  │                          │
+│ KafkaRecordProtobufSerializer ──────────────→│  ▼                          │
+│  │                          │ ModelBinding   │ KafkaRecord (POCO)          │
+│  ▼                          │ Data (bytes)   │  │                          │
+│ ParameterBindingData        │                │  ▼                          │
+│  source: "AzureKafkaRecord" │                │ User Function               │
+│  content_type: protobuf     │                │                             │
+└─────────────────────────────┘                └─────────────────────────────┘
+```
+
+### Key Components
+
+| Component | Repository | Role |
+|-----------|-----------|------|
+| `KafkaRecordProtobufSerializer` | azure-functions-kafka-extension | Serializes `IKafkaEventData` → Protobuf bytes |
+| `KafkaRecordProto.proto` | Both repos (identical schema) | Protobuf schema definition |
+| `KafkaEventDataConvertManager` | azure-functions-kafka-extension | Routes `ParameterBindingData` conversion |
+| `KafkaRecordConverter` | azure-functions-dotnet-worker | Deserializes Protobuf → `KafkaRecord` POCO |
+| `KafkaRecord` | azure-functions-dotnet-worker | User-facing POCO type |
+
+### Protobuf Schema
+
+```protobuf
+message KafkaRecordProto {
+    string topic = 1;
+    int32 partition = 2;
+    int64 offset = 3;
+    bytes key = 4;              // native bytes, zero overhead
+    bytes value = 5;            // native bytes, zero overhead
+    KafkaTimestampProto timestamp = 6;
+    repeated KafkaHeaderProto headers = 7;
+    optional int32 leader_epoch = 8;
+}
+```
+
+The Host does not inspect `ModelBindingData.content` — it is an opaque pass-through. This means:
+- No Azure Functions Host changes required
+- No Host release dependency
+- The serialization format is an internal contract between the Kafka Extension and Worker Extension only
+
+---
+
+## Configuration
+
+**No new configuration is needed.** The binding type is determined by the function parameter type at build time:
+
+| Parameter Type | Binding Path | Serialization |
+|---------------|-------------|---------------|
+| `string` | Value → string | None |
+| `byte[]` | Value → byte array | None |
+| `KafkaEventData<T>` | Full event → JSON | JSON |
+| **`KafkaRecord`** | **Full record → Protobuf** | **Protobuf** |
+
+All existing `host.json` settings (`extensions.kafka.*`), trigger attributes (`BrokerList`, `Topic`, `ConsumerGroup`, SASL/SSL, etc.), and scaling configuration (`LagThreshold`) work identically regardless of the binding type.
+
+---
+
+## Impact Analysis
+
+### Scale Controller: No Impact
+
+The Scale Controller uses `KafkaTriggerMetrics` (TotalLag, PartitionCount) via `IScaleMonitor`, which queries Kafka broker metadata directly. It never touches `ModelBindingData` or cares about the user's binding type.
+
+### Existing Bindings: No Impact
+
+`KafkaRecord` is a new, parallel code path activated only when the user's function parameter is `KafkaRecord` or `KafkaRecord[]`. The existing `string`, `byte[]`, and `KafkaEventData<T>` paths are completely untouched.
+
+### Performance: Opt-in, Marginal Overhead
+
+| Aspect | Impact |
+|--------|--------|
+| **Users NOT using `KafkaRecord`** | Zero impact — code path unchanged |
+| **Users using `KafkaRecord`** | Marginal increase in gRPC payload (metadata: ~50-200 bytes fixed overhead per message) |
+| **Serialization cost** | Protobuf is faster than JSON+Base64 alternative; comparable to EventHubs/ServiceBus SDK type binding |
+| **Memory** | One additional `KafkaRecord` allocation per message (lightweight POCO) |
+
+For a 1KB message payload, the metadata overhead is ~5-10%. For larger messages, it becomes negligible.
+
+### Comparison with Other Extensions
+
+| Extension | SDK Type Binding | Serialization | Performance Pattern |
+|-----------|-----------------|---------------|-------------------|
+| EventHubs | `EventData` | AMQP binary | SDK type via `AmqpAnnotatedMessage` |
+| ServiceBus | `ServiceBusReceivedMessage` | AMQP binary | SDK type via `AmqpAnnotatedMessage` |
+| **Kafka** | **`KafkaRecord`** | **Protobuf binary** | **Same pattern, different wire format** |
+
+### Dependencies Added
+
+| Package | Kafka Extension (Host) | Worker Extension |
+|---------|----------------------|-----------------|
+| `Grpc.Tools` | Yes (build-time only, `PrivateAssets=All`) | Yes (build-time only) |
+| `Google.Protobuf` | No (transitive via Confluent) | Yes (explicit, no transitive path) |
+
+No new runtime dependencies are introduced to the Kafka Extension. `Grpc.Tools` is build-time only.
+
+---
+
+## Cross-Repository Coordination
+
+This feature spans two repositories that must be released together:
+
+| Repository | Package | Changes |
+|-----------|---------|---------|
+| `Azure/azure-functions-kafka-extension` | `Microsoft.Azure.WebJobs.Extensions.Kafka` | Protobuf serializer, ConvertManager update |
+| `Azure/azure-functions-dotnet-worker` | `Microsoft.Azure.Functions.Worker.Extensions.Kafka` | KafkaRecord types, IInputConverter |
+
+**Release order**: Both packages must be published simultaneously. If only one side is updated:
+- Host-only update: Sends `AzureKafkaRecord` Protobuf, but Worker has no converter → `KafkaRecord` binding fails (existing bindings unaffected)
+- Worker-only update: Worker has converter, but Host sends old format → converter never matches (existing bindings unaffected)
+
+In either partial-update scenario, **existing bindings continue to work** — only the new `KafkaRecord` binding would be non-functional until both sides are updated.
+
+---
+
+## Future Work (Phase 3+)
+
+- **E2E tests**: Docker-based Kafka integration tests for `KafkaRecord` single and batch dispatch
+- **Cross-language support**: Node.js, Java, Python, PowerShell — each language worker needs a `KafkaRecord` equivalent type and converter
+- **Documentation**: README updates, binding reference, samples

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -38,7 +38,6 @@
     <PackageReference Include="Confluent.SchemaRegistry" Version="2.4.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.4.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.4.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
     <PackageReference Include="Grpc.Tools" Version="2.60.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -38,10 +38,17 @@
     <PackageReference Include="Confluent.SchemaRegistry" Version="2.4.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.4.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.4.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.60.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Threading.Channels" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="Serialization\KafkaRecordProto.proto" GrpcServices="None" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProto.proto
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProto.proto
@@ -12,8 +12,8 @@ message KafkaRecordProto {
     string topic = 1;
     int32 partition = 2;
     int64 offset = 3;
-    bytes key = 4;
-    bytes value = 5;
+    optional bytes key = 4;
+    optional bytes value = 5;
     KafkaTimestampProto timestamp = 6;
     repeated KafkaHeaderProto headers = 7;
     optional int32 leader_epoch = 8;
@@ -29,5 +29,5 @@ message KafkaTimestampProto {
 
 message KafkaHeaderProto {
     string key = 1;
-    bytes value = 2;
+    optional bytes value = 2;
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProto.proto
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProto.proto
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+syntax = "proto3";
+package azure.functions.kafka;
+option csharp_namespace = "Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization";
+
+// Represents a single Kafka record aligned with the Apache Kafka specification.
+// Used as the serialization schema for ModelBindingData transport between
+// the host-side Kafka Extension and language worker extensions.
+message KafkaRecordProto {
+    string topic = 1;
+    int32 partition = 2;
+    int64 offset = 3;
+    bytes key = 4;
+    bytes value = 5;
+    KafkaTimestampProto timestamp = 6;
+    repeated KafkaHeaderProto headers = 7;
+    optional int32 leader_epoch = 8;
+
+    // Reserved for future fields. Do not reuse field numbers.
+    reserved 9 to 15;
+}
+
+message KafkaTimestampProto {
+    int64 unix_timestamp_ms = 1;
+    int32 type = 2; // 0=NotAvailable, 1=CreateTime, 2=LogAppendTime
+}
+
+message KafkaHeaderProto {
+    string key = 1;
+    bytes value = 2;
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProtobufSerializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProtobufSerializer.cs
@@ -35,8 +35,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization
                 Topic = eventData.Topic ?? string.Empty,
                 Partition = eventData.Partition,
                 Offset = eventData.Offset,
-                Key = ToByteString(eventData.Key),
-                Value = ToByteString(eventData.Value),
                 Timestamp = new KafkaTimestampProto
                 {
                     UnixTimestampMs = new DateTimeOffset(
@@ -47,6 +45,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization
                 },
             };
 
+            if (eventData.Key != null)
+            {
+                proto.Key = ToByteString(eventData.Key);
+            }
+
+            if (eventData.Value != null)
+            {
+                proto.Value = ToByteString(eventData.Value);
+            }
+
             if (eventData.LeaderEpoch.HasValue)
             {
                 proto.LeaderEpoch = eventData.LeaderEpoch.Value;
@@ -56,13 +64,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization
             {
                 foreach (var header in eventData.Headers)
                 {
-                    proto.Headers.Add(new KafkaHeaderProto
+                    var headerProto = new KafkaHeaderProto
                     {
                         Key = header.Key ?? string.Empty,
-                        Value = header.Value != null
-                            ? ByteString.CopyFrom(header.Value)
-                            : ByteString.Empty,
-                    });
+                    };
+                    if (header.Value != null)
+                    {
+                        headerProto.Value = ByteString.CopyFrom(header.Value);
+                    }
+
+                    proto.Headers.Add(headerProto);
                 }
             }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProtobufSerializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProtobufSerializer.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using Google.Protobuf;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization
+{
+    /// <summary>
+    /// Serializes <see cref="IKafkaEventData"/> to a Protobuf-encoded byte array
+    /// using the <see cref="KafkaRecordProto"/> schema. This format is used for
+    /// ModelBindingData transport to isolated workers, avoiding Base64 overhead.
+    /// </summary>
+    internal static class KafkaRecordProtobufSerializer
+    {
+        /// <summary>
+        /// The binding source identifier used in ModelBindingData.
+        /// </summary>
+        public const string BindingSource = "AzureKafkaRecord";
+
+        /// <summary>
+        /// The content type for the serialized data.
+        /// </summary>
+        public const string ContentType = "application/x-protobuf";
+
+        /// <summary>
+        /// Serializes an <see cref="IKafkaEventData"/> to a Protobuf byte array.
+        /// </summary>
+        public static byte[] Serialize(IKafkaEventData eventData)
+        {
+            var proto = new KafkaRecordProto
+            {
+                Topic = eventData.Topic ?? string.Empty,
+                Partition = eventData.Partition,
+                Offset = eventData.Offset,
+                Key = ToByteString(eventData.Key),
+                Value = ToByteString(eventData.Value),
+                Timestamp = new KafkaTimestampProto
+                {
+                    UnixTimestampMs = new DateTimeOffset(
+                        eventData.Timestamp.Kind == DateTimeKind.Utc
+                            ? eventData.Timestamp
+                            : eventData.Timestamp.ToUniversalTime()).ToUnixTimeMilliseconds(),
+                    Type = 0, // NotAvailable — IKafkaEventData doesn't preserve TimestampType
+                },
+            };
+
+            if (eventData.LeaderEpoch.HasValue)
+            {
+                proto.LeaderEpoch = eventData.LeaderEpoch.Value;
+            }
+
+            if (eventData.Headers != null)
+            {
+                foreach (var header in eventData.Headers)
+                {
+                    proto.Headers.Add(new KafkaHeaderProto
+                    {
+                        Key = header.Key ?? string.Empty,
+                        Value = header.Value != null
+                            ? ByteString.CopyFrom(header.Value)
+                            : ByteString.Empty,
+                    });
+                }
+            }
+
+            return proto.ToByteArray();
+        }
+
+        private static ByteString ToByteString(object value)
+        {
+            if (value == null)
+            {
+                return ByteString.Empty;
+            }
+
+            if (value is byte[] bytes)
+            {
+                return ByteString.CopyFrom(bytes);
+            }
+
+            if (value is string str)
+            {
+                return ByteString.CopyFrom(str, Encoding.UTF8);
+            }
+
+            // For complex types (Avro, Protobuf, POCOs), serialize to JSON bytes
+            var json = JsonConvert.SerializeObject(value);
+            return ByteString.CopyFrom(json, Encoding.UTF8);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaEventDataConvertManager.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaEventDataConvertManager.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Avro.Generic;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -81,12 +82,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         private Task<object> ConvertToParameterBindingData(object src, Attribute attribute, ValueBindingContext context)
         {
             var eventData = (IKafkaEventData)src;
-            var content = KafkaRecordSerializer.Serialize(eventData);
+            var content = KafkaRecordProtobufSerializer.Serialize(eventData);
             var bindingData = new ParameterBindingData(
                 "1.0",
-                KafkaRecordSerializer.BindingSource,
+                KafkaRecordProtobufSerializer.BindingSource,
                 new BinaryData(content),
-                KafkaRecordSerializer.JsonContentType);
+                KafkaRecordProtobufSerializer.ContentType);
             return Task.FromResult<object>(bindingData);
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
@@ -14,10 +14,13 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Tests;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
@@ -1299,6 +1302,144 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 $"Expected at least {maxRetries + 1} attempts for message 1, got {message1Attempts}");
             Assert.True(message2Attempts >= 1,
                 $"Expected message 2 to be attempted at least once after message 1 was force-committed, got {message2Attempts}");
+        }
+
+        /// <summary>
+        /// E2E test for KafkaRecord Protobuf serialization (PR #619, Phase 2a).
+        /// Produces messages to a real Kafka broker, consumes them via trigger,
+        /// then converts the consumed events to ParameterBindingData using
+        /// KafkaEventDataConvertManager and verifies the Protobuf payload
+        /// preserves value, topic, partition, offset, and timestamp.
+        /// </summary>
+        [Fact]
+        public async Task KafkaRecord_ProtobufSerialization_PreservesValueAndBrokerMetadata()
+        {
+            var input = Enumerable.Range(1, 5)
+                .Select(x => new KafkaEventData<string>
+                {
+                    Value = "protobuf-e2e-" + x.ToString()
+                });
+
+            var output = await ProduceAndConsumeAsync<
+                KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>,
+                KafkaTriggerForProduceAndConsume<KafkaEventData<string>>>(
+                x => x.Produce(default), input);
+
+            Assert.Equal(5, output.Count);
+
+            var convertManager = new KafkaEventDataConvertManager(null, NullLogger.Instance);
+            var converter = convertManager.GetConverter<KafkaTriggerAttribute>(
+                typeof(IKafkaEventData), typeof(ParameterBindingData));
+            Assert.NotNull(converter);
+
+            foreach (var consumedEvent in output)
+            {
+                var result = await converter(consumedEvent, new KafkaTriggerAttribute("broker", "topic"), null);
+                Assert.IsType<ParameterBindingData>(result);
+
+                var bindingData = (ParameterBindingData)result;
+                Assert.Equal("1.0", bindingData.Version);
+                Assert.Equal("AzureKafkaRecord", bindingData.Source);
+                Assert.Equal("application/x-protobuf", bindingData.ContentType);
+
+                var proto = KafkaRecordProto.Parser.ParseFrom(bindingData.Content);
+
+                // Value preserved
+                Assert.Contains("protobuf-e2e-", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
+
+                // Broker-assigned metadata is populated
+                Assert.Equal(Constants.StringTopicWithTenPartitionsName, proto.Topic);
+                Assert.True(proto.Partition >= 0, "Partition should be >= 0");
+                Assert.True(proto.Offset >= 0, "Offset should be >= 0");
+                Assert.NotNull(proto.Timestamp);
+                Assert.True(proto.Timestamp.UnixTimestampMs > 0, "Timestamp should be > 0");
+            }
+        }
+
+        /// <summary>
+        /// E2E test verifying that Kafka message headers survive the full
+        /// Kafka produce/consume round-trip AND Protobuf serialization.
+        /// </summary>
+        [Fact]
+        public async Task KafkaRecord_ProtobufSerialization_PreservesHeaders()
+        {
+            var input = Enumerable.Range(1, 3)
+                .Select(x =>
+                {
+                    var eventData = new KafkaEventData<string>
+                    {
+                        Value = "header-test-" + x.ToString()
+                    };
+                    eventData.Headers.Add("correlationId", Encoding.UTF8.GetBytes("corr-" + x));
+                    eventData.Headers.Add("source", Encoding.UTF8.GetBytes("e2e-test"));
+                    return eventData;
+                });
+
+            var output = await ProduceAndConsumeAsync<
+                KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>,
+                KafkaTriggerForProduceAndConsume<KafkaEventData<string>>>(
+                x => x.Produce(default), input);
+
+            Assert.Equal(3, output.Count);
+
+            var convertManager = new KafkaEventDataConvertManager(null, NullLogger.Instance);
+            var converter = convertManager.GetConverter<KafkaTriggerAttribute>(
+                typeof(IKafkaEventData), typeof(ParameterBindingData));
+
+            foreach (var consumedEvent in output)
+            {
+                var result = await converter(consumedEvent, new KafkaTriggerAttribute("broker", "topic"), null);
+                var bindingData = (ParameterBindingData)result;
+                var proto = KafkaRecordProto.Parser.ParseFrom(bindingData.Content);
+
+                // Headers preserved in Protobuf
+                Assert.Equal(2, proto.Headers.Count);
+
+                var correlationHeader = proto.Headers.First(h => h.Key == "correlationId");
+                Assert.StartsWith("corr-", Encoding.UTF8.GetString(correlationHeader.Value.ToByteArray()));
+
+                var sourceHeader = proto.Headers.First(h => h.Key == "source");
+                Assert.Equal("e2e-test", Encoding.UTF8.GetString(sourceHeader.Value.ToByteArray()));
+            }
+        }
+
+        /// <summary>
+        /// E2E test verifying that messages produced without a key result in
+        /// the Protobuf key field being absent (not set) after serialization.
+        /// </summary>
+        [Fact]
+        public async Task KafkaRecord_ProtobufSerialization_NullKey_IsOmitted()
+        {
+            var input = Enumerable.Range(1, 3)
+                .Select(x => new KafkaEventData<string>
+                {
+                    Value = "nullkey-test-" + x.ToString()
+                });
+
+            var output = await ProduceAndConsumeAsync<
+                KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>,
+                KafkaTriggerForProduceAndConsume<KafkaEventData<string>>>(
+                x => x.Produce(default), input);
+
+            Assert.Equal(3, output.Count);
+
+            var convertManager = new KafkaEventDataConvertManager(null, NullLogger.Instance);
+            var converter = convertManager.GetConverter<KafkaTriggerAttribute>(
+                typeof(IKafkaEventData), typeof(ParameterBindingData));
+
+            foreach (var consumedEvent in output)
+            {
+                var result = await converter(consumedEvent, new KafkaTriggerAttribute("broker", "topic"), null);
+                var bindingData = (ParameterBindingData)result;
+                var proto = KafkaRecordProto.Parser.ParseFrom(bindingData.Content);
+
+                // Key should not be set (null key from producer)
+                Assert.False(proto.HasKey, "Key should not be set for null-key messages");
+
+                // Value should still be present
+                Assert.True(proto.HasValue, "Value should be set");
+                Assert.Contains("nullkey-test-", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Confluent.SchemaRegistry" Version="2.4.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.4.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.4.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.0" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaEventDataConvertManagerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaEventDataConvertManagerTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
@@ -53,23 +54,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.IsType<ParameterBindingData>(result);
             var bindingData = (ParameterBindingData)result;
             Assert.Equal("1.0", bindingData.Version);
-            Assert.Equal(KafkaRecordSerializer.BindingSource, bindingData.Source);
-            Assert.Equal(KafkaRecordSerializer.JsonContentType, bindingData.ContentType);
+            Assert.Equal(KafkaRecordProtobufSerializer.BindingSource, bindingData.Source);
+            Assert.Equal(KafkaRecordProtobufSerializer.ContentType, bindingData.ContentType);
 
-            // Verify content is valid JSON with expected fields
-            var json = JObject.Parse(bindingData.Content.ToString());
-            Assert.Equal("test-topic", json["topic"].Value<string>());
-            Assert.Equal(3, json["partition"].Value<int>());
-            Assert.Equal(42L, json["offset"].Value<long>());
-            Assert.Equal(5, json["leaderEpoch"].Value<int>());
-            Assert.False(json["isPartitionEOF"].Value<bool>());
-            Assert.Equal("test-key", json["message"]["key"].Value<string>());
-            Assert.Equal("test-value", json["message"]["value"].Value<string>());
+            // Verify content is valid Protobuf with expected fields
+            var proto = KafkaRecordProto.Parser.ParseFrom(bindingData.Content);
+            Assert.Equal("test-topic", proto.Topic);
+            Assert.Equal(3, proto.Partition);
+            Assert.Equal(42L, proto.Offset);
+            Assert.Equal(5, proto.LeaderEpoch);
+            Assert.Equal("test-key", Encoding.UTF8.GetString(proto.Key.ToByteArray()));
+            Assert.Equal("test-value", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
 
             // Headers
-            var headers = json["message"]["headers"] as JArray;
-            Assert.Single(headers);
-            Assert.Equal("h1", headers[0]["key"].Value<string>());
+            Assert.Single(proto.Headers);
+            Assert.Equal("h1", proto.Headers[0].Key);
+            Assert.Equal("v1", Encoding.UTF8.GetString(proto.Headers[0].Value.ToByteArray()));
         }
 
         [Fact]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaRecordProtobufSerializerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaRecordProtobufSerializerTest.cs
@@ -1,0 +1,209 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    public class KafkaRecordProtobufSerializerTest
+    {
+        [Fact]
+        public void Serialize_SingleEvent_ProducesValidProtobuf()
+        {
+            var eventData = new KafkaEventData<string, string>("myKey", "myValue")
+            {
+                Offset = 42,
+                Partition = 3,
+                Topic = "test-topic",
+                Timestamp = new DateTime(2026, 1, 15, 10, 30, 0, DateTimeKind.Utc),
+                LeaderEpoch = 7,
+            };
+
+            var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+
+            Assert.NotNull(bytes);
+            Assert.True(bytes.Length > 0);
+
+            // Round-trip: deserialize and verify
+            var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
+            Assert.Equal("test-topic", proto.Topic);
+            Assert.Equal(3, proto.Partition);
+            Assert.Equal(42, proto.Offset);
+            Assert.Equal(7, proto.LeaderEpoch);
+            Assert.True(proto.HasLeaderEpoch);
+            Assert.Equal("myKey", Encoding.UTF8.GetString(proto.Key.ToByteArray()));
+            Assert.Equal("myValue", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
+            Assert.NotNull(proto.Timestamp);
+            Assert.True(proto.Timestamp.UnixTimestampMs > 0);
+        }
+
+        [Fact]
+        public void Serialize_NullLeaderEpoch_OmitsField()
+        {
+            var eventData = new KafkaEventData<string, string>("key", "value")
+            {
+                Offset = 1,
+                Partition = 0,
+                Topic = "topic",
+                Timestamp = DateTime.UtcNow,
+                LeaderEpoch = null,
+            };
+
+            var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+            var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
+
+            Assert.False(proto.HasLeaderEpoch);
+        }
+
+        [Fact]
+        public void Serialize_NullKey_SerializesAsEmptyBytes()
+        {
+            var eventData = new KafkaEventData<string>("testValue")
+            {
+                Offset = 0,
+                Partition = 0,
+                Topic = "topic",
+                Timestamp = DateTime.UtcNow,
+            };
+
+            var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+            var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
+
+            Assert.True(proto.Key.IsEmpty);
+            Assert.Equal("testValue", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
+        }
+
+        [Fact]
+        public void Serialize_ByteArrayValue_PreservedExactly()
+        {
+            var binaryValue = new byte[] { 0x00, 0x01, 0xFF, 0xFE, 0x42 };
+            var binaryKey = new byte[] { 0xAA, 0xBB };
+            var eventData = new KafkaEventData<byte[], byte[]>(binaryKey, binaryValue)
+            {
+                Offset = 100,
+                Partition = 1,
+                Topic = "binary-topic",
+                Timestamp = DateTime.UtcNow,
+            };
+
+            var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+            var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
+
+            Assert.Equal(binaryValue, proto.Value.ToByteArray());
+            Assert.Equal(binaryKey, proto.Key.ToByteArray());
+        }
+
+        [Fact]
+        public void Serialize_WithHeaders_AllPreserved()
+        {
+            var eventData = new KafkaEventData<string, string>("key", "value")
+            {
+                Offset = 5,
+                Partition = 0,
+                Topic = "headers-topic",
+                Timestamp = DateTime.UtcNow,
+            };
+            eventData.Headers.Add("correlationId", Encoding.UTF8.GetBytes("abc-123"));
+            eventData.Headers.Add("traceParent", Encoding.UTF8.GetBytes("00-trace"));
+
+            var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+            var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
+
+            Assert.Equal(2, proto.Headers.Count);
+            Assert.Equal("correlationId", proto.Headers[0].Key);
+            Assert.Equal("abc-123", Encoding.UTF8.GetString(proto.Headers[0].Value.ToByteArray()));
+            Assert.Equal("traceParent", proto.Headers[1].Key);
+            Assert.Equal("00-trace", Encoding.UTF8.GetString(proto.Headers[1].Value.ToByteArray()));
+        }
+
+        [Fact]
+        public void Serialize_NoHeaders_ProducesEmptyList()
+        {
+            var eventData = new KafkaEventData<string, string>("key", "value")
+            {
+                Offset = 0,
+                Partition = 0,
+                Topic = "topic",
+                Timestamp = DateTime.UtcNow,
+            };
+
+            var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+            var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
+
+            Assert.Empty(proto.Headers);
+        }
+
+        [Fact]
+        public void Serialize_TimestampPreserved()
+        {
+            var timestamp = new DateTime(2026, 3, 15, 14, 30, 45, DateTimeKind.Utc);
+            var expectedMs = new DateTimeOffset(timestamp).ToUnixTimeMilliseconds();
+
+            var eventData = new KafkaEventData<string, string>("key", "value")
+            {
+                Offset = 0,
+                Partition = 0,
+                Topic = "topic",
+                Timestamp = timestamp,
+            };
+
+            var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+            var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
+
+            Assert.Equal(expectedMs, proto.Timestamp.UnixTimestampMs);
+            Assert.Equal(0, proto.Timestamp.Type); // NotAvailable — IKafkaEventData doesn't preserve TimestampType
+        }
+
+        [Fact]
+        public void BindingSource_IsAzureKafkaRecord()
+        {
+            Assert.Equal("AzureKafkaRecord", KafkaRecordProtobufSerializer.BindingSource);
+        }
+
+        [Fact]
+        public void ContentType_IsProtobuf()
+        {
+            Assert.Equal("application/x-protobuf", KafkaRecordProtobufSerializer.ContentType);
+        }
+
+        [Fact]
+        public void Serialize_NullValue_SerializesAsEmptyBytes()
+        {
+            var eventData = new KafkaEventData<string>()
+            {
+                Offset = 0,
+                Partition = 0,
+                Topic = "topic",
+                Timestamp = DateTime.UtcNow,
+            };
+
+            var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+            var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
+
+            Assert.True(proto.Value.IsEmpty);
+        }
+
+        [Fact]
+        public void Serialize_HeaderWithNullValue_PreservesNullAsEmpty()
+        {
+            var eventData = new KafkaEventData<string, string>("key", "value")
+            {
+                Offset = 0,
+                Partition = 0,
+                Topic = "topic",
+                Timestamp = DateTime.UtcNow,
+            };
+            eventData.Headers.Add("nullHeader", null);
+
+            var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+            var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
+
+            Assert.Single(proto.Headers);
+            Assert.Equal("nullHeader", proto.Headers[0].Key);
+            Assert.True(proto.Headers[0].Value.IsEmpty);
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
@@ -30,6 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Phase 2a of raw Kafka record support: Add Protobuf serialization on the host-side Kafka Extension for transmitting KafkaRecord data to isolated workers via ModelBindingData.

## Issue
Relates to #612
Fixes #618

## Changes

### New files
- **KafkaRecordProto.proto** - Protobuf schema for Apache Kafka spec-aligned record (topic, partition, offset, key/value as native bytes, timestamp, headers, optional leader_epoch)
- **KafkaRecordProtobufSerializer.cs** - Serializes IKafkaEventData to Protobuf byte array with zero Base64 overhead
- **KafkaRecordProtobufSerializerTest.cs** - 11 unit tests covering round-trip, null handling, binary data, headers, timestamps

### Modified files
- **KafkaEventDataConvertManager.cs** - ParameterBindingData converter now emits Protobuf (source: AzureKafkaRecord, content_type: application/x-protobuf) instead of JSON
- **KafkaEventDataConvertManagerTest.cs** - Updated to validate Protobuf output
- **csproj** - Added Grpc.Tools for .proto compilation; removed unnecessary Google.Protobuf explicit dependency (provided transitively by Confluent.SchemaRegistry.Serdes.Protobuf)
- **UnitTests.csproj** - Added Google.Protobuf for test deserialization

## Breaking Changes
None. All existing binding types (string, byte[], KafkaEventData) continue to work unchanged.

## Testing
- [x] Unit tests: 213 passed (1 pre-existing SSL env test excluded)
- [x] Architecture lint: PASSED, 0 errors, 0 warnings
- [x] Vulnerability scan: clean
- [ ] E2E tests: skip (requires Docker Kafka environment; Phase 3 scope)
- [x] Coverage: 65.9% line (above 60% threshold)

## Self-Review Checklist
- [x] No intermediate files (PLAN, SOLUTION, coverage output)
- [x] No debug statements or TODO comments
- [x] No hardcoded credentials or sensitive data
- [x] Commit messages follow conventional format

## Note
This PR covers **host-side only** (Phase 2a). The worker-side KafkaRecord POCO types and IInputConverter are in a separate PR against azure-functions-dotnet-worker. Both packages must be released together for the KafkaRecord binding to function end-to-end.
