### PR TITLE
fix: Use PIPELINE_ADMIN PAT for release workflows

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           ref: master
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PIPELINE_ADMIN }}
 
       - name: Create release branch from master
         run: |
@@ -100,7 +100,7 @@ jobs:
 
       - name: Ensure release label exists
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PIPELINE_ADMIN }}
         run: |
           gh label create "release" --description "Release PR" --color "0E8A16" 2>/dev/null || echo "Label 'release' already exists"
 
@@ -123,7 +123,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PIPELINE_ADMIN }}
         run: |
           CHANGELOG=$(cat /tmp/changelog.txt)
           PR_BODY=$(cat <<'PREOF'
@@ -157,7 +157,7 @@ jobs:
 
       - name: Create Draft GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PIPELINE_ADMIN }}
         run: |
           CHANGELOG=$(cat /tmp/changelog.txt)
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: master
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PIPELINE_ADMIN }}
 
       - name: Verify version in common.props
         run: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Publish draft GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PIPELINE_ADMIN }}
         run: |
           # Find the draft release and publish it
           gh release edit "${{ env.VERSION }}" --draft=false
@@ -78,7 +78,7 @@ jobs:
 
       - name: Clean up release branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PIPELINE_ADMIN }}
         run: |
           git push origin --delete "release/${{ env.VERSION }}" 2>/dev/null || true
           echo "Cleaned up branch: release/${{ env.VERSION }}"


### PR DESCRIPTION
## Fix: Use PIPELINE_ADMIN PAT for release workflows

### Problem
The release-prep workflow fails with:
```
GitHub Actions is not permitted to create or approve pull requests
```
This is because the Azure Org policy blocks `GITHUB_TOKEN` from creating PRs.

### Fix
Replace `GITHUB_TOKEN` with `PIPELINE_ADMIN` PAT in both `release-prep.yml` and `release-tag.yml` for:
- `actions/checkout` token (needed for git push)
- `gh pr create` (PR creation)
- `gh label create` (label creation)
- `gh release create` / `gh release edit` (release management)
- `gh release delete` (cleanup)
- Branch deletion cleanup

### Note
`PIPELINE_ADMIN` is the same secret used by the original `release.yml` before this automation was added. It should already be configured in the repo's Actions secrets.
