### PR TITLE
fix: Add dev version bump to release-tag pipeline + bump to 4.3.0

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -83,6 +83,33 @@ jobs:
           git push origin --delete "release/${{ env.VERSION }}" 2>/dev/null || true
           echo "Cleaned up branch: release/${{ env.VERSION }}"
 
+      - name: Bump version on dev branch
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_ADMIN }}
+        run: |
+          # After releasing X.Y.Z on master, dev's common.props must be
+          # updated to X.Y.Z$(VersionSuffix) so it stays in sync.
+          # Without this, dev retains the OLD version indefinitely.
+          BUMP_BRANCH="auto/bump-dev-to-${{ env.VERSION }}"
+
+          git fetch origin dev
+          git checkout -b "$BUMP_BRANCH" origin/dev
+
+          # Update version — preserve $(VersionSuffix) for dev builds
+          sed -i 's|<Version>[^<]*|<Version>'"${{ env.VERSION }}"'$(VersionSuffix)|' build/common.props
+          echo "Updated dev common.props:"
+          grep '<Version>' build/common.props
+
+          git add build/common.props
+          git commit -m "Bump version to ${{ env.VERSION }} on dev after release"
+          git push origin "$BUMP_BRANCH"
+
+          gh pr create \
+            --base dev \
+            --head "$BUMP_BRANCH" \
+            --title "Bump version to ${{ env.VERSION }} on dev after release" \
+            --body "Automated version bump after release **${{ env.VERSION }}**."$'\n\n'"Updates \`build/common.props\` from the pre-release version to \`${{ env.VERSION }}\$(VersionSuffix)\`."
+
       - name: Summary
         run: |
           echo "## Release ${{ env.VERSION }} Tagged :tada:" >> $GITHUB_STEP_SUMMARY
@@ -94,6 +121,10 @@ jobs:
           echo "1. [Code Mirror](https://azfunc.visualstudio.com/internal/_build?definitionId=541) — mirrors tag to internal repo" >> $GITHUB_STEP_SUMMARY
           echo "2. [Official Build](https://azfunc.visualstudio.com/internal/_build?definitionId=690) — builds + signs NuGet package" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Dev branch" >> $GITHUB_STEP_SUMMARY
+          echo "- Version bump PR created for \`dev\` → \`${{ env.VERSION }}\$(VersionSuffix)\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Manual steps remaining" >> $GITHUB_STEP_SUMMARY
           echo "3. Run [Release Pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=1553) with artifact from Official Build" >> $GITHUB_STEP_SUMMARY
           echo "4. Run [.NET Partner Pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=4442) with path \`azure-functions-kafka-extension/net/${{ env.VERSION }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "5. Merge the dev version bump PR" >> $GITHUB_STEP_SUMMARY

--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>4.2.0$(VersionSuffix)</Version>
+    <Version>4.3.0$(VersionSuffix)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>


### PR DESCRIPTION
## Problem

`release-tag.yml` did not update `dev` branch's `common.props` after a release. This caused `dev` to stay at **4.2.0** even after 4.3.0 was released on `master`.

The "Verify version in common.props" step in `release-tag` only checks `master` (which was already updated by `release-prep`), so the mismatch was never caught.

## Fix

### 1. Pipeline: auto-create dev version bump PR
Added a **"Bump version on dev branch"** step to `release-tag.yml` that runs after tag creation and release publish:
- Creates a branch from `dev`
- Updates `common.props` to `X.Y.Z$(VersionSuffix)`
- Opens a PR to `dev`

### 2. Immediate: bump dev to 4.3.0
Updates `build/common.props` on `dev` from `4.2.0` to `4.3.0` to reflect the completed 4.3.0 release.

## Next
After this merges, `release-prep 4.3.1` can be run for the next release.
