### PR TITLE
fix: Add idle backoff in ProcessSubscription to prevent CPU busy-loop

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -259,6 +259,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             }
         }
 
+        int subscriberIdleBackoffMs = 50;
+        /// <summary>
+        /// Defines the backoff interval in milliseconds when the subscriber receives
+        /// no messages from Consume(). Prevents busy-looping when the topic is idle.
+        /// Set to 0 to disable (useful in unit tests that control timing externally).
+        ///
+        /// default: 50ms
+        /// </summary>
+        public int SubscriberIdleBackoffMs
+        {
+            get => this.subscriberIdleBackoffMs;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new InvalidOperationException("SubscriberIdleBackoffMs must be 0 or a positive integer.");
+                }
+
+                this.subscriberIdleBackoffMs = value;
+            }
+        }
+
         public string Format()
         {
             var serializerSettings = new JsonSerializerSettings()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                             }
                             else
                             {
-                                // TODO: maybe slow down if there isn't much incoming data
+                                // No data available — outer loop will back off
                                 break;
                             }
                         }
@@ -338,6 +338,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                     if (!alreadyFlushedInCurrentExecution)
                     {
                         this.functionExecutor.Flush(listenerCancellationTokenSource.Token);
+                    }
+
+                    // When Consume() returned no messages during the entire batch window,
+                    // back off to avoid busy-looping. Without this, the outer loop spins
+                    // at full CPU speed because Consume() may return null immediately
+                    // (e.g., no data on the topic, or in unit tests with mocked consumers).
+                    if (!alreadyFlushedInCurrentExecution && this.options.SubscriberIdleBackoffMs > 0)
+                    {
+                        Thread.Sleep(this.options.SubscriberIdleBackoffMs);
                     }
                 }
             }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
@@ -528,6 +528,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             Assert.True(options.CommitOnFailure);
             Assert.Equal(5, options.MaxRetries);
+            Assert.Equal(50, options.SubscriberIdleBackoffMs);
+        }
+
+        // ====================================================================
+        // KafkaOptions: SubscriberIdleBackoffMs validation
+        // ====================================================================
+        [Fact]
+        public void KafkaOptions_SubscriberIdleBackoffMs_AcceptsValidValues()
+        {
+            var options = new KafkaOptions();
+
+            // 0 is valid (disables backoff, useful in tests)
+            options.SubscriberIdleBackoffMs = 0;
+            Assert.Equal(0, options.SubscriberIdleBackoffMs);
+
+            // Positive values are valid
+            options.SubscriberIdleBackoffMs = 100;
+            Assert.Equal(100, options.SubscriberIdleBackoffMs);
+        }
+
+        [Fact]
+        public void KafkaOptions_SubscriberIdleBackoffMs_RejectsNegative()
+        {
+            var options = new KafkaOptions();
+
+            Assert.Throws<InvalidOperationException>(() => options.SubscriberIdleBackoffMs = -1);
         }
     }
 }


### PR DESCRIPTION
## Problem

The subscriber thread in `ProcessSubscription` busy-loops when `Consume()` returns null (no messages). On CI machines with few cores, this starves the ThreadPool and causes the reader task (which handles function execution and offset commits) to time out.

This is the root cause of the flaky test **`MultiItem_FunctionFails_RetriesInPlaceThenSucceeds`** tracked in #622.

### How it happens

1. `Consume(TimeSpan)` is called with ~1 second timeout
2. In production, Kafka blocks for that duration; in tests, the mock returns null instantly
3. After all messages are consumed, the outer loop spins with no delay:
   `Consume(1s) -> null (instant) -> Flush(empty=no-op) -> loop (microseconds)`
4. This saturates 1 CPU core, starving the ThreadPool-based reader task
5. Reader can't complete function retry + commit within the 10s test timeout

The original code had a TODO acknowledging this:
`// TODO: maybe slow down if there isn't much incoming data`

## Fix

Add a new `SubscriberIdleBackoffMs` property to `KafkaOptions` (default 50ms):

`csharp
// KafkaListener.cs — ProcessSubscription
if (!alreadyFlushedInCurrentExecution && this.options.SubscriberIdleBackoffMs > 0)
{
    Thread.Sleep(this.options.SubscriberIdleBackoffMs);
}
`

### Design choices

- **New property instead of reusing `ChannelFullRetryIntervalInMs`**: Different semantic — "channel is full, retry write" vs "no messages, back off". Users may want to tune them independently.
- **`Thread.Sleep` instead of `await Task.Delay`**: `ProcessSubscription` runs on a dedicated `Thread` (not ThreadPool), and `Consume()` is a synchronous librdkafka API. Blocking the dedicated thread is correct; async would require restructuring the entire consume loop.
- **0 disables backoff**: Useful in unit tests that control timing externally.
- **Windows timer resolution ~15.6ms**: Values below 16ms are effectively the same on Windows. Default 50ms yields ~62ms actual sleep (4 timer ticks), which is sufficient.

## Verification

- All 225 unit tests pass (223 existing + 2 new)
- Previously flaky test passes 5/5 consecutive runs
- CI will verify on low-core machines

Fixes #622
