### PR TITLE
[Release] 4.3.1

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -107,26 +107,48 @@ jobs:
       - name: Generate changelog from dev commits
         id: changelog
         run: |
-          # Get the last release tag to generate changelog
-          LAST_TAG=$(git describe --tags --abbrev=0 origin/master 2>/dev/null || echo "")
-          echo "Last tag: $LAST_TAG"
+          # Find the changelog base: the most recent version bump commit on dev.
+          # We cannot use tags directly because tags live on master, and master/dev
+          # have divergent commit graphs (asymmetric branches). Using a master tag
+          # as the base for "git log TAG..origin/dev" includes the entire dev history
+          # since the branches diverged — not just post-release changes.
+          #
+          # Instead, find the last commit on dev that touched build/common.props
+          # (which is the version bump PR created by release-tag.yml after each release).
+          BUMP_COMMIT=$(git log origin/dev --first-parent --format="%H" -- build/common.props | head -1)
+          echo "Last version bump commit on dev: $BUMP_COMMIT"
 
-          if [ -n "$LAST_TAG" ]; then
-            CHANGELOG=$(git log --oneline "$LAST_TAG..origin/dev" --no-merges --pretty=format:"- %s" | head -100)
+          if [ -n "$BUMP_COMMIT" ]; then
+            git log --oneline "$BUMP_COMMIT" -1
+
+            # --first-parent: only include squash-merged PRs on dev (not
+            # internal feature branch commits merged into those PRs).
+            # --invert-grep: exclude version bump and CI-only commits.
+            git log "$BUMP_COMMIT..origin/dev" --first-parent --no-merges \
+              --pretty=format:"- %s" \
+              --grep="^Bump version" --grep="^Update common.props" \
+              --grep="^Updating extension version" --grep="^Update version" \
+              --invert-grep \
+              | head -50 > /tmp/changelog.txt
           else
-            CHANGELOG="Initial release"
+            echo "Initial release" > /tmp/changelog.txt
           fi
 
-          # Write to file to avoid escaping issues
-          echo "$CHANGELOG" > /tmp/changelog.txt
-          echo "Generated changelog with $(echo "$CHANGELOG" | wc -l) entries"
+          # If no entries (e.g., only the version bump itself), note it
+          if [ ! -s /tmp/changelog.txt ]; then
+            echo "- No functional changes since last release" > /tmp/changelog.txt
+          fi
+
+          echo "Generated changelog with $(wc -l < /tmp/changelog.txt) entries"
+          cat /tmp/changelog.txt
 
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ secrets.PIPELINE_ADMIN }}
         run: |
-          CHANGELOG=$(cat /tmp/changelog.txt)
-          PR_BODY=$(cat <<'PREOF'
+          # Build PR body from template + changelog file to avoid
+          # shell variable expansion issues with special characters.
+          cat > /tmp/pr-body.md <<'PREOF'
           ## Release ${{ env.VERSION }}
 
           This PR syncs the `dev` branch content to `master` for release **${{ env.VERSION }}**.
@@ -144,22 +166,32 @@ jobs:
 
           ### Changes since last release
           PREOF
-          )
-          PR_BODY="${PR_BODY}
-          ${CHANGELOG}"
+
+          cat /tmp/changelog.txt >> /tmp/pr-body.md
 
           gh pr create \
             --base master \
             --head "release/${{ env.VERSION }}" \
             --title "[Release] ${{ env.VERSION }}" \
-            --body "$PR_BODY" \
+            --body-file /tmp/pr-body.md \
             --label "release"
 
       - name: Create Draft GitHub Release
         env:
           GH_TOKEN: ${{ secrets.PIPELINE_ADMIN }}
         run: |
-          CHANGELOG=$(cat /tmp/changelog.txt)
+          # Find the previous tag for the "Full Changelog" compare link
+          LAST_TAG=$(git tag -l --sort=-version:refname '[0-9]*.[0-9]*.[0-9]*' | head -1)
+          COMPARE_BASE="${LAST_TAG:-dev}"
+
+          # Build release notes from changelog file to avoid shell
+          # variable expansion issues in --notes inline strings.
+          {
+            echo "## What's Changed"
+            cat /tmp/changelog.txt
+            echo ""
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${COMPARE_BASE}...${{ env.VERSION }}"
+          } > /tmp/release-notes.md
 
           # Delete any leftover draft release from a previous failed run
           gh release delete "${{ env.VERSION }}" --yes 2>/dev/null || true
@@ -167,11 +199,8 @@ jobs:
           gh release create "${{ env.VERSION }}" \
             --draft \
             --title "${{ env.VERSION }}" \
-            --notes "## What's Changed
-          $CHANGELOG
-
-          **Full Changelog**: https://github.com/${{ github.repository }}/compare/$(git describe --tags --abbrev=0 origin/master 2>/dev/null || echo 'dev')...${{ env.VERSION }}" \
-            --target master
+            --notes-file /tmp/release-notes.md \
+            --target "release/${{ env.VERSION }}"
 
       - name: Summary
         run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -83,6 +83,33 @@ jobs:
           git push origin --delete "release/${{ env.VERSION }}" 2>/dev/null || true
           echo "Cleaned up branch: release/${{ env.VERSION }}"
 
+      - name: Bump version on dev branch
+        env:
+          GH_TOKEN: ${{ secrets.PIPELINE_ADMIN }}
+        run: |
+          # After releasing X.Y.Z on master, dev's common.props must be
+          # updated to X.Y.Z$(VersionSuffix) so it stays in sync.
+          # Without this, dev retains the OLD version indefinitely.
+          BUMP_BRANCH="auto/bump-dev-to-${{ env.VERSION }}"
+
+          git fetch origin dev
+          git checkout -b "$BUMP_BRANCH" origin/dev
+
+          # Update version — preserve $(VersionSuffix) for dev builds
+          sed -i 's|<Version>[^<]*|<Version>'"${{ env.VERSION }}"'$(VersionSuffix)|' build/common.props
+          echo "Updated dev common.props:"
+          grep '<Version>' build/common.props
+
+          git add build/common.props
+          git commit -m "Bump version to ${{ env.VERSION }} on dev after release"
+          git push origin "$BUMP_BRANCH"
+
+          gh pr create \
+            --base dev \
+            --head "$BUMP_BRANCH" \
+            --title "Bump version to ${{ env.VERSION }} on dev after release" \
+            --body "Automated version bump after release **${{ env.VERSION }}**."$'\n\n'"Updates \`build/common.props\` from the pre-release version to \`${{ env.VERSION }}\$(VersionSuffix)\`."
+
       - name: Summary
         run: |
           echo "## Release ${{ env.VERSION }} Tagged :tada:" >> $GITHUB_STEP_SUMMARY
@@ -94,6 +121,10 @@ jobs:
           echo "1. [Code Mirror](https://azfunc.visualstudio.com/internal/_build?definitionId=541) — mirrors tag to internal repo" >> $GITHUB_STEP_SUMMARY
           echo "2. [Official Build](https://azfunc.visualstudio.com/internal/_build?definitionId=690) — builds + signs NuGet package" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Dev branch" >> $GITHUB_STEP_SUMMARY
+          echo "- Version bump PR created for \`dev\` → \`${{ env.VERSION }}\$(VersionSuffix)\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Manual steps remaining" >> $GITHUB_STEP_SUMMARY
           echo "3. Run [Release Pipeline](https://azfunc.visualstudio.com/internal/_build?definitionId=1553) with artifact from Official Build" >> $GITHUB_STEP_SUMMARY
           echo "4. Run [.NET Partner Pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=4442) with path \`azure-functions-kafka-extension/net/${{ env.VERSION }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "5. Merge the dev version bump PR" >> $GITHUB_STEP_SUMMARY

--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaOptions.cs
@@ -259,6 +259,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             }
         }
 
+        int subscriberIdleBackoffMs = 50;
+        /// <summary>
+        /// Defines the backoff interval in milliseconds when the subscriber receives
+        /// no messages from Consume(). Prevents busy-looping when the topic is idle.
+        /// Set to 0 to disable (useful in unit tests that control timing externally).
+        ///
+        /// default: 50ms
+        /// </summary>
+        public int SubscriberIdleBackoffMs
+        {
+            get => this.subscriberIdleBackoffMs;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new InvalidOperationException("SubscriberIdleBackoffMs must be 0 or a positive integer.");
+                }
+
+                this.subscriberIdleBackoffMs = value;
+            }
+        }
+
         public string Format()
         {
             var serializerSettings = new JsonSerializerSettings()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                             }
                             else
                             {
-                                // TODO: maybe slow down if there isn't much incoming data
+                                // No data available — outer loop will back off
                                 break;
                             }
                         }
@@ -338,6 +338,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                     if (!alreadyFlushedInCurrentExecution)
                     {
                         this.functionExecutor.Flush(listenerCancellationTokenSource.Token);
+                    }
+
+                    // When Consume() returned no messages during the entire batch window,
+                    // back off to avoid busy-looping. Without this, the outer loop spins
+                    // at full CPU speed because Consume() may return null immediately
+                    // (e.g., no data on the topic, or in unit tests with mocked consumers).
+                    if (!alreadyFlushedInCurrentExecution && this.options.SubscriberIdleBackoffMs > 0)
+                    {
+                        Thread.Sleep(this.options.SubscriberIdleBackoffMs);
                     }
                 }
             }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
@@ -528,6 +528,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             Assert.True(options.CommitOnFailure);
             Assert.Equal(5, options.MaxRetries);
+            Assert.Equal(50, options.SubscriberIdleBackoffMs);
+        }
+
+        // ====================================================================
+        // KafkaOptions: SubscriberIdleBackoffMs validation
+        // ====================================================================
+        [Fact]
+        public void KafkaOptions_SubscriberIdleBackoffMs_AcceptsValidValues()
+        {
+            var options = new KafkaOptions();
+
+            // 0 is valid (disables backoff, useful in tests)
+            options.SubscriberIdleBackoffMs = 0;
+            Assert.Equal(0, options.SubscriberIdleBackoffMs);
+
+            // Positive values are valid
+            options.SubscriberIdleBackoffMs = 100;
+            Assert.Equal(100, options.SubscriberIdleBackoffMs);
+        }
+
+        [Fact]
+        public void KafkaOptions_SubscriberIdleBackoffMs_RejectsNegative()
+        {
+            var options = new KafkaOptions();
+
+            Assert.Throws<InvalidOperationException>(() => options.SubscriberIdleBackoffMs = -1);
         }
     }
 }


### PR DESCRIPTION
## Release 4.3.1

This PR syncs the `dev` branch content to `master` for release **4.3.1**.

### What this PR does
- Replaces master tree with dev content (tree replacement, not merge)
- Removes dev-only files (samples/, Architecture.md, AGENT-RULES.md, lint-architecture.ps1)
- Updates version in `build/common.props` to `4.3.1`

### After merge
The `release-tag` workflow will automatically:
1. Create tag `4.3.1` on master
2. Publish the draft GitHub Release
3. ADO Code Mirror → Official Build → Release Pipeline will follow

### Changes since last release
- fix: Use dev version bump commit as changelog base instead of tags (#630)
- fix: Fix changelog generation and draft release in release-prep (#628)