### PR TITLE
feat: add OidcManaged OAuth bearer method for managed token acquisition on Flex Consumption Plan

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -522,6 +522,8 @@ Only these classes may directly reference `Confluent.Kafka` types:
 | `AsyncCommitStrategy` | `IConsumer<TKey, TValue>.StoreOffset()` |
 | `KafkaListenerConfiguration` | `SaslMechanism`, `SecurityProtocol` enums |
 | `BrokerAuthenticationMode` / `BrokerProtocol` | Enum mapping to Confluent types |
+| `OidcManagedAuth` | `ConsumerBuilder`, `ProducerBuilder`, `AdminClientBuilder`, `IClient` (wiring `SetOAuthBearerTokenRefreshHandler`) |
+| `OidcAuthenticationHeaderValueProvider` | `Confluent.SchemaRegistry.IAuthenticationHeaderValueProvider` |
 
 **Why**: Isolating Confluent.Kafka references to specific classes makes it possible to upgrade the Confluent.Kafka version with minimal blast radius.
 

--- a/lint-architecture.ps1
+++ b/lint-architecture.ps1
@@ -230,6 +230,11 @@ function Test-ConfluentKafkaIsolation {
         # Offset commit (consumer.StoreOffset)
         "AsyncCommitStrategy.cs",
         "ICommitStrategy.cs",
+        # OIDC managed-auth helpers (wire SetOAuthBearerTokenRefreshHandler on
+        # ConsumerBuilder/ProducerBuilder/AdminClientBuilder and adapt tokens
+        # to Schema Registry's IAuthenticationHeaderValueProvider).
+        "OidcManagedAuth.cs",
+        "OidcAuthenticationHeaderValueProvider.cs",
         # Config & Enums (maps to Confluent types)
         "KafkaListenerConfiguration.cs",
         "BrokerAuthenticationMode.cs",

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OAuthBearerMethod.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OAuthBearerMethod.cs
@@ -13,6 +13,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Config
     public enum OAuthBearerMethod
     {
         Default,
-        Oidc
+        Oidc,
+
+        /// <summary>
+        /// OIDC client-credentials flow performed in managed .NET code rather than
+        /// delegated to librdkafka's libcurl-based token fetch. Uses HttpClient to
+        /// POST to <c>OAuthBearerTokenEndpointUrl</c> and supplies the resulting
+        /// token to librdkafka via <c>SetOAuthBearerTokenRefreshHandler</c>. Avoids
+        /// the platform-specific CA-bundle issue that affects librdkafka's OIDC
+        /// path on some Linux images (e.g. Azure Functions Flex).
+        /// </summary>
+        OidcManaged
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OidcAuthenticationHeaderValueProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OidcAuthenticationHeaderValueProvider.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net.Http.Headers;
+using Confluent.SchemaRegistry;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Config
+{
+    /// <summary>
+    /// Adapts <see cref="OidcTokenProvider"/> to Confluent's Schema Registry
+    /// authentication callback so the same managed OIDC token is used for SR
+    /// HTTPS calls as for Kafka broker SASL/OAUTHBEARER.
+    /// </summary>
+    internal sealed class OidcAuthenticationHeaderValueProvider : IAuthenticationHeaderValueProvider
+    {
+        private readonly OidcTokenProvider tokenProvider;
+
+        public OidcAuthenticationHeaderValueProvider(OidcTokenProvider tokenProvider)
+        {
+            this.tokenProvider = tokenProvider;
+        }
+
+        public AuthenticationHeaderValue GetAuthenticationHeader()
+        {
+            var (token, _) = this.tokenProvider.GetTokenAsync().GetAwaiter().GetResult();
+            return new AuthenticationHeaderValue("Bearer", token);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OidcManagedAuth.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OidcManagedAuth.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Config
+{
+    /// <summary>
+    /// Helpers that wire a shared <see cref="OidcTokenProvider"/> into the
+    /// various Confluent.Kafka client builders via
+    /// <c>SetOAuthBearerTokenRefreshHandler</c>.
+    /// </summary>
+    internal static class OidcManagedAuth
+    {
+        /// <summary>
+        /// Indicates whether the given method requires managed (.NET-side)
+        /// token acquisition.
+        /// </summary>
+        public static bool IsManaged(OAuthBearerMethod method) => method == OAuthBearerMethod.OidcManaged;
+
+        public static OidcTokenProvider CreateProvider(string tokenEndpointUrl, string clientId, string clientSecret, string scope, string extensions)
+        {
+            if (string.IsNullOrWhiteSpace(tokenEndpointUrl))
+            {
+                throw new ArgumentException("OAuthBearerTokenEndpointUrl is required when OAuthBearerMethod is OidcManaged.", nameof(tokenEndpointUrl));
+            }
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentException("OAuthBearerClientId is required when OAuthBearerMethod is OidcManaged.", nameof(clientId));
+            }
+            if (string.IsNullOrWhiteSpace(clientSecret))
+            {
+                throw new ArgumentException("OAuthBearerClientSecret is required when OAuthBearerMethod is OidcManaged.", nameof(clientSecret));
+            }
+            return new OidcTokenProvider(tokenEndpointUrl, clientId, clientSecret, scope, extensions);
+        }
+
+        public static void WireConsumer<TKey, TValue>(ConsumerBuilder<TKey, TValue> builder, OidcTokenProvider provider, ILogger logger)
+        {
+            builder.SetOAuthBearerTokenRefreshHandler((client, _) => RefreshToken(client, provider, logger));
+        }
+
+        public static void WireProducer<TKey, TValue>(ProducerBuilder<TKey, TValue> builder, OidcTokenProvider provider, ILogger logger)
+        {
+            builder.SetOAuthBearerTokenRefreshHandler((client, _) => RefreshToken(client, provider, logger));
+        }
+
+        public static void WireAdminClient(AdminClientBuilder builder, OidcTokenProvider provider, ILogger logger)
+        {
+            builder.SetOAuthBearerTokenRefreshHandler((client, _) => RefreshToken(client, provider, logger));
+        }
+
+        /// <summary>
+        /// Synchronously sets an initial OAUTHBEARER token on a client. Required for
+        /// clients that aren't actively polled (scaler Consumer, single-shot AdminClient)
+        /// because librdkafka blocks in TRY_CONNECT until a token is set, and the
+        /// refresh-handler callback is only dispatched via Consume()/Poll() activity.
+        /// </summary>
+        public static void PrimeToken(IClient client, OidcTokenProvider provider, ILogger logger)
+        {
+            RefreshToken(client, provider, logger);
+        }
+
+        private static void RefreshToken(IClient client, OidcTokenProvider provider, ILogger logger)
+        {
+            logger?.LogInformation("Acquiring managed OIDC token for client {ClientName}", client?.Name ?? "<unknown>");
+            try
+            {
+                var (token, expiresAtUnixMs) = provider.GetTokenAsync(logger).GetAwaiter().GetResult();
+                client.OAuthBearerSetToken(token, expiresAtUnixMs, provider.PrincipalName, provider.Extensions);
+                logger?.LogInformation(
+                    "OIDC token set on client {ClientName}, expires at {ExpiresAt:o} (principal={Principal}, extensions={ExtensionCount})",
+                    client?.Name ?? "<unknown>",
+                    DateTimeOffset.FromUnixTimeMilliseconds(expiresAtUnixMs),
+                    provider.PrincipalName,
+                    provider.Extensions?.Count ?? 0);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Failed to acquire managed OIDC token for client {ClientName}", client?.Name ?? "<unknown>");
+                client.OAuthBearerSetTokenFailure(ex.ToString());
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OidcTokenProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OidcTokenProvider.cs
@@ -1,0 +1,157 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Config
+{
+    /// <summary>
+    /// Performs OAuth2 client-credentials token acquisition in managed .NET code,
+    /// bypassing librdkafka's libcurl-based OIDC path. Caches the token in memory
+    /// and refreshes a configurable window before expiry.
+    /// </summary>
+    /// <remarks>
+    /// One instance is shared across the Kafka client(s) and the Schema Registry
+    /// client so the same access token serves both. Thread-safe.
+    /// </remarks>
+    internal sealed class OidcTokenProvider
+    {
+        private static readonly HttpClient SharedHttpClient = new HttpClient();
+        private static readonly TimeSpan RefreshSkew = TimeSpan.FromSeconds(60);
+
+        private readonly string tokenEndpointUrl;
+        private readonly string clientId;
+        private readonly string clientSecret;
+        private readonly string scope;
+        private readonly IDictionary<string, string> extensions;
+        private readonly SemaphoreSlim refreshLock = new SemaphoreSlim(1, 1);
+
+        private string cachedToken;
+        private DateTimeOffset cachedExpiresAt = DateTimeOffset.MinValue;
+
+        public OidcTokenProvider(string tokenEndpointUrl, string clientId, string clientSecret, string scope, string extensionsString)
+        {
+            this.tokenEndpointUrl = tokenEndpointUrl ?? throw new ArgumentNullException(nameof(tokenEndpointUrl));
+            this.clientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+            this.clientSecret = clientSecret ?? throw new ArgumentNullException(nameof(clientSecret));
+            this.scope = scope;
+            this.extensions = ParseExtensions(extensionsString);
+        }
+
+        public string PrincipalName => this.clientId;
+
+        public IDictionary<string, string> Extensions => this.extensions;
+
+        public Task<(string Token, long ExpiresAtUnixMs)> GetTokenAsync(CancellationToken cancellationToken = default)
+        {
+            return GetTokenAsync(null, cancellationToken);
+        }
+
+        public async Task<(string Token, long ExpiresAtUnixMs)> GetTokenAsync(ILogger logger, CancellationToken cancellationToken = default)
+        {
+            if (this.cachedToken != null && DateTimeOffset.UtcNow + RefreshSkew < this.cachedExpiresAt)
+            {
+                return (this.cachedToken, this.cachedExpiresAt.ToUnixTimeMilliseconds());
+            }
+
+            await this.refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (this.cachedToken != null && DateTimeOffset.UtcNow + RefreshSkew < this.cachedExpiresAt)
+                {
+                    return (this.cachedToken, this.cachedExpiresAt.ToUnixTimeMilliseconds());
+                }
+
+                (this.cachedToken, this.cachedExpiresAt) = await FetchTokenAsync(logger, cancellationToken).ConfigureAwait(false);
+                return (this.cachedToken, this.cachedExpiresAt.ToUnixTimeMilliseconds());
+            }
+            finally
+            {
+                this.refreshLock.Release();
+            }
+        }
+
+        private async Task<(string Token, DateTimeOffset ExpiresAt)> FetchTokenAsync(ILogger logger, CancellationToken cancellationToken)
+        {
+            logger?.LogInformation(
+                "Fetching OIDC token from {TokenEndpoint} (clientId={ClientId}, scope={Scope})",
+                this.tokenEndpointUrl,
+                this.clientId,
+                string.IsNullOrWhiteSpace(this.scope) ? "<none>" : this.scope);
+
+            var form = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("grant_type", "client_credentials"),
+                new KeyValuePair<string, string>("client_id", this.clientId),
+                new KeyValuePair<string, string>("client_secret", this.clientSecret),
+            };
+            if (!string.IsNullOrWhiteSpace(this.scope))
+            {
+                form.Add(new KeyValuePair<string, string>("scope", this.scope));
+            }
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, this.tokenEndpointUrl)
+            {
+                Content = new FormUrlEncodedContent(form)
+            };
+
+            using var response = await SharedHttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException(
+                    $"OIDC token endpoint '{this.tokenEndpointUrl}' returned {(int)response.StatusCode}: {body}");
+            }
+
+            var json = JObject.Parse(body);
+            var token = (string)json["access_token"];
+            if (string.IsNullOrEmpty(token))
+            {
+                throw new InvalidOperationException(
+                    $"OIDC token response from '{this.tokenEndpointUrl}' did not contain access_token.");
+            }
+
+            var expiresInSeconds = (int?)json["expires_in"] ?? 3600;
+            var expiresAt = DateTimeOffset.UtcNow.AddSeconds(expiresInSeconds);
+            logger?.LogInformation(
+                "OIDC token fetched from {TokenEndpoint}, expires in {ExpiresInSeconds}s at {ExpiresAt:o}",
+                this.tokenEndpointUrl,
+                expiresInSeconds,
+                expiresAt);
+            return (token, expiresAt);
+        }
+
+        internal static IDictionary<string, string> ParseExtensions(string extensionsString)
+        {
+            var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (string.IsNullOrWhiteSpace(extensionsString))
+            {
+                return dict;
+            }
+
+            foreach (var pair in extensionsString.Split(','))
+            {
+                var trimmed = pair.Trim();
+                if (trimmed.Length == 0)
+                {
+                    continue;
+                }
+                var eq = trimmed.IndexOf('=');
+                if (eq <= 0 || eq == trimmed.Length - 1)
+                {
+                    throw new ArgumentException(
+                        $"Invalid OAuthBearerExtensions entry '{trimmed}'. Expected key=value pairs separated by commas.",
+                        nameof(extensionsString));
+                }
+                dict[trimmed.Substring(0, eq)] = trimmed.Substring(eq + 1);
+            }
+            return dict;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.Config;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
@@ -127,7 +128,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 logger.Log((LogLevel)m.LevelAs(LogLevelType.MicrosoftExtensionsLogging), $"Libkafka: {m?.Message}");
             });
 
-            return builder.Build();
+            OidcTokenProvider oidcProvider = null;
+            if (OidcManagedAuth.IsManaged(this.listenerConfiguration.SaslOAuthBearerMethod))
+            {
+                oidcProvider = OidcManagedAuth.CreateProvider(
+                    this.listenerConfiguration.SaslOAuthBearerTokenEndpointUrl,
+                    this.listenerConfiguration.SaslOAuthBearerClientId,
+                    this.listenerConfiguration.SaslOAuthBearerClientSecret,
+                    this.listenerConfiguration.SaslOAuthBearerScope,
+                    this.listenerConfiguration.SaslOAuthBearerExtensions);
+                OidcManagedAuth.WireConsumer(builder, oidcProvider, this.logger);
+            }
+
+            var builtConsumer = builder.Build();
+            if (oidcProvider != null)
+            {
+                OidcManagedAuth.PrimeToken(builtConsumer, oidcProvider, this.logger);
+            }
+            return builtConsumer;
         }
 
         private KafkaMetricsProvider<TKey, TValue> CreateMetricsProvider()
@@ -207,13 +225,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 SslCertificatePem = this.listenerConfiguration.SslCertificatePEM,
                 SslKeyPem = this.listenerConfiguration.SslKeyPEM,
 
-                // OAuthBearer config
-                SaslOauthbearerMethod = this.listenerConfiguration.SaslOAuthBearerMethod,
-                SaslOauthbearerClientId = this.listenerConfiguration.SaslOAuthBearerClientId,
-                SaslOauthbearerClientSecret = this.listenerConfiguration.SaslOAuthBearerClientSecret,
-                SaslOauthbearerScope = this.listenerConfiguration.SaslOAuthBearerScope,
-                SaslOauthbearerTokenEndpointUrl = this.listenerConfiguration.SaslOAuthBearerTokenEndpointUrl,
-                SaslOauthbearerExtensions = this.listenerConfiguration.SaslOAuthBearerExtensions,
+                // OAuthBearer config. When OidcManaged is selected we deliberately leave
+                // these librdkafka properties unset so the native OIDC flow is not used;
+                // instead the managed handler is wired on the builder below.
 
                 // Values from host configuration
                 StatisticsIntervalMs = this.options.StatisticsIntervalMs,
@@ -228,6 +242,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 MetadataMaxAgeMs = this.options.MetadataMaxAgeMs,
                 SocketKeepaliveEnable = this.options.SocketKeepaliveEnable
             };
+
+            if (!OidcManagedAuth.IsManaged(this.listenerConfiguration.SaslOAuthBearerMethod))
+            {
+                conf.SaslOauthbearerMethod = (SaslOauthbearerMethod)this.listenerConfiguration.SaslOAuthBearerMethod;
+                conf.SaslOauthbearerClientId = this.listenerConfiguration.SaslOAuthBearerClientId;
+                conf.SaslOauthbearerClientSecret = this.listenerConfiguration.SaslOAuthBearerClientSecret;
+                conf.SaslOauthbearerScope = this.listenerConfiguration.SaslOAuthBearerScope;
+                conf.SaslOauthbearerTokenEndpointUrl = this.listenerConfiguration.SaslOAuthBearerTokenEndpointUrl;
+                conf.SaslOauthbearerExtensions = this.listenerConfiguration.SaslOAuthBearerExtensions;
+            }
 
             if (string.IsNullOrEmpty(this.listenerConfiguration.EventHubConnectionString))
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaMetricsProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaMetricsProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Confluent.Kafka;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.Config;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -16,20 +17,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         private readonly AdminClientConfig adminClientConfig;
         private readonly IConsumer<TKey, TValue> consumer;
         private readonly ILogger logger;
+        private readonly OidcTokenProvider oidcTokenProvider;
         protected Lazy<List<TopicPartition>> topicPartitions;
 
         virtual protected internal KafkaTriggerMetrics LastCalculatedMetrics { get; set; }
 
-        internal KafkaMetricsProvider(string topicName, AdminClientConfig adminClientConfig, IConsumer<TKey, TValue> consumer, ILogger logger) : this(topicName, adminClientConfig, logger)
+        internal KafkaMetricsProvider(string topicName, AdminClientConfig adminClientConfig, IConsumer<TKey, TValue> consumer, ILogger logger)
+            : this(topicName, adminClientConfig, consumer, logger, null)
+        {
+        }
+
+        internal KafkaMetricsProvider(string topicName, AdminClientConfig adminClientConfig, IConsumer<TKey, TValue> consumer, ILogger logger, OidcTokenProvider oidcTokenProvider)
+            : this(topicName, adminClientConfig, logger, oidcTokenProvider)
         {
             this.consumer = consumer;
         }
 
         internal KafkaMetricsProvider(string topicName, AdminClientConfig adminClientConfig, ILogger logger)
+            : this(topicName, adminClientConfig, logger, null)
+        {
+        }
+
+        internal KafkaMetricsProvider(string topicName, AdminClientConfig adminClientConfig, ILogger logger, OidcTokenProvider oidcTokenProvider)
         {
             this.topicName = topicName;
             this.adminClientConfig = adminClientConfig;
             this.logger = logger;
+            this.oidcTokenProvider = oidcTokenProvider;
             this.topicPartitions = new Lazy<List<TopicPartition>>(LoadTopicPartitions);
             this.LastCalculatedMetrics = null;
         }
@@ -68,7 +82,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             try
             {
                 var timeout = TimeSpan.FromSeconds(5);
-                using var adminClient = new AdminClientBuilder(adminClientConfig).Build();
+                var adminBuilder = new AdminClientBuilder(adminClientConfig);
+                if (oidcTokenProvider != null)
+                {
+                    OidcManagedAuth.WireAdminClient(adminBuilder, oidcTokenProvider, logger);
+                }
+                using var adminClient = adminBuilder.Build();
+                if (oidcTokenProvider != null)
+                {
+                    OidcManagedAuth.PrimeToken(adminClient, oidcTokenProvider, logger);
+                }
                 var metadata = adminClient.GetMetadata(this.topicName, timeout);
                 if (metadata.Topics == null || metadata.Topics.Count == 0)
                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaScalerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaScalerProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Confluent.Kafka;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.Config;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Logging;
@@ -39,8 +40,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             ILogger logger = loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Kafka"));
 
             var consumerConfig = GetConsumerConfiguration(kafkaMetadata, config, nameResolver);
-            var consumer = new ConsumerBuilder<string, string>(consumerConfig).Build();
-            var metricsProvider = new KafkaMetricsProvider<string, string>(topicName, new AdminClientConfig(consumerConfig), consumer, logger);
+
+            OidcTokenProvider tokenProvider = null;
+            if (kafkaMetadata.AuthenticationMode == BrokerAuthenticationMode.OAuthBearer &&
+                OidcManagedAuth.IsManaged(kafkaMetadata.OAuthBearerMethod))
+            {
+                tokenProvider = OidcManagedAuth.CreateProvider(
+                    config.ResolveSecureSetting(nameResolver, kafkaMetadata.OAuthBearerTokenEndpointUrl),
+                    config.ResolveSecureSetting(nameResolver, kafkaMetadata.OAuthBearerClientId),
+                    config.ResolveSecureSetting(nameResolver, kafkaMetadata.OAuthBearerClientSecret),
+                    config.ResolveSecureSetting(nameResolver, kafkaMetadata.OAuthBearerScope),
+                    config.ResolveSecureSetting(nameResolver, kafkaMetadata.OAuthBearerExtensions));
+            }
+
+            var consumerBuilder = new ConsumerBuilder<string, string>(consumerConfig);
+            if (tokenProvider != null)
+            {
+                OidcManagedAuth.WireConsumer(consumerBuilder, tokenProvider, logger);
+            }
+            var consumer = consumerBuilder.Build();
+            if (tokenProvider != null)
+            {
+                OidcManagedAuth.PrimeToken(consumer, tokenProvider, logger);
+            }
+            var metricsProvider = new KafkaMetricsProvider<string, string>(topicName, new AdminClientConfig(consumerConfig), consumer, logger, tokenProvider);
 
             _scaleMonitor = new KafkaObjectTopicScaler(topicName, consumerGroup, metricsProvider, triggerMetadata.FunctionName, lagThreshold, logger);
             _targetScaler = new KafkaObjectTargetScaler(topicName, consumerGroup, metricsProvider, triggerMetadata.FunctionName, lagThreshold, logger);
@@ -79,7 +102,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                     adminConfig.SecurityProtocol = (SecurityProtocol)kafkaMetaData.Protocol;
                 }
 
-                if (kafkaMetaData.AuthenticationMode == BrokerAuthenticationMode.OAuthBearer)
+                if (kafkaMetaData.AuthenticationMode == BrokerAuthenticationMode.OAuthBearer &&
+                    !OidcManagedAuth.IsManaged(kafkaMetaData.OAuthBearerMethod))
                 {
                     adminConfig.SaslOauthbearerMethod = (SaslOauthbearerMethod)kafkaMetaData.OAuthBearerMethod;
                     adminConfig.SaslOauthbearerClientId = config.ResolveSecureSetting(nameResolver, kafkaMetaData.OAuthBearerClientId);
@@ -187,7 +211,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             public string OAuthBearerExtensions { get; set; }
 
             [JsonProperty]
-            public SaslOauthbearerMethod OAuthBearerMethod { get; set; }
+            public OAuthBearerMethod OAuthBearerMethod { get; set; }
 
             public void ResolveProperties(IConfiguration config, INameResolver resolver)
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Text;
 using System.Text.RegularExpressions;
 using Confluent.Kafka;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.Config;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -43,7 +44,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             var producerConfig = this.GetProducerConfig(entity);
             var producerKey = CreateKeyForConfig(producerConfig);
 
-            var baseProducer = baseProducers.GetOrAdd(producerKey, (k) => CreateBaseProducer(producerConfig));
+            OidcTokenProvider tokenProvider = null;
+            if (entity.Attribute.AuthenticationMode == BrokerAuthenticationMode.OAuthBearer &&
+                OidcManagedAuth.IsManaged(entity.Attribute.OAuthBearerMethod))
+            {
+                tokenProvider = OidcManagedAuth.CreateProvider(
+                    this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerTokenEndpointUrl),
+                    this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerClientId),
+                    this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerClientSecret),
+                    this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerScope),
+                    this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerExtensions));
+            }
+
+            var baseProducer = baseProducers.GetOrAdd(producerKey, (k) => CreateBaseProducer(producerConfig, tokenProvider));
             return Create(baseProducer.Handle, entity);
         }
 
@@ -66,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return keyBuilder.ToString();
         }
 
-        private IProducer<byte[], byte[]> CreateBaseProducer(ProducerConfig producerConfig)
+        private IProducer<byte[], byte[]> CreateBaseProducer(ProducerConfig producerConfig, OidcTokenProvider tokenProvider)
         {
             var builder = new ProducerBuilder<byte[], byte[]>(producerConfig);
             ILogger logger = this.loggerFactory.CreateLogger("Kafka");
@@ -75,7 +88,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 logger.Log((LogLevel)m.LevelAs(LogLevelType.MicrosoftExtensionsLogging), $"Libkafka: {m?.Message}");
             });
 
-            return builder.Build();
+            if (tokenProvider != null)
+            {
+                OidcManagedAuth.WireProducer(builder, tokenProvider, logger);
+            }
+
+            var producer = builder.Build();
+            if (tokenProvider != null)
+            {
+                OidcManagedAuth.PrimeToken(producer, tokenProvider, logger);
+            }
+            return producer;
         }
 
         private IKafkaProducer Create(Handle producerBaseHandle, KafkaProducerEntity entity)
@@ -90,15 +113,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             var schemaRegistryPassword = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.SchemaRegistryPassword);
             var topic = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.Topic);
 
+            Confluent.SchemaRegistry.IAuthenticationHeaderValueProvider schemaRegistryAuthProvider = null;
+            if (entity.Attribute.AuthenticationMode == BrokerAuthenticationMode.OAuthBearer &&
+                OidcManagedAuth.IsManaged(entity.Attribute.OAuthBearerMethod))
+            {
+                var srTokenProvider = OidcManagedAuth.CreateProvider(
+                    this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerTokenEndpointUrl),
+                    this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerClientId),
+                    this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerClientSecret),
+                    this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerScope),
+                    this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerExtensions));
+                schemaRegistryAuthProvider = new OidcAuthenticationHeaderValueProvider(srTokenProvider);
+            }
+
             (var valueSerializer, var keySerializer) = SerializationHelper.ResolveSerializers(
-                valueType, 
-                keyType, 
-                valueAvroSchema, 
-                keyAvroSchema, 
-                schemaRegistryUrl, 
-                schemaRegistryUsername, 
+                valueType,
+                keyType,
+                valueAvroSchema,
+                keyAvroSchema,
+                schemaRegistryUrl,
+                schemaRegistryUsername,
                 schemaRegistryPassword,
-                topic);
+                topic,
+                schemaRegistryAuthProvider);
 
             return (IKafkaProducer)Activator.CreateInstance(
                 typeof(KafkaProducer<,>).MakeGenericType(keyType, valueType),
@@ -193,7 +230,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 conf.SecurityProtocol = (SecurityProtocol)entity.Attribute.Protocol;
             }
 
-            if (entity.Attribute.AuthenticationMode == BrokerAuthenticationMode.OAuthBearer)
+            if (entity.Attribute.AuthenticationMode == BrokerAuthenticationMode.OAuthBearer &&
+                !OidcManagedAuth.IsManaged(entity.Attribute.OAuthBearerMethod))
             {
                 conf.SaslOauthbearerMethod = (SaslOauthbearerMethod)entity.Attribute.OAuthBearerMethod;
                 conf.SaslOauthbearerClientId = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerClientId);

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/SerializationHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/SerializationHelper.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 {
     internal static class SerializationHelper
     {
-        internal static (object, object) ResolveDeserializers(GetKeyAndValueTypesResult keyAndValueTypes, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword, string topic)
+        internal static (object, object) ResolveDeserializers(GetKeyAndValueTypesResult keyAndValueTypes, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword, string topic, IAuthenticationHeaderValueProvider schemaRegistryAuthProvider = null)
         {
             object valueDeserializer = null;
             object keyDeserializer = null;
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             // call helper if schema registry is specified and return avro deserializers
             if (schemaRegistryUrl != null)
             {
-                return ResolveSchemaRegistryDeserializers(valueType, keyType, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword, topic);
+                return ResolveSchemaRegistryDeserializers(valueType, keyType, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword, topic, schemaRegistryAuthProvider);
             }
 
             // check for protobuf deserialization
@@ -98,12 +98,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return (valueDeserializer, keyDeserializer);
         }
 
-        internal static (object, object) ResolveSchemaRegistryDeserializers(Type valueType, Type keyType, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword, string topic)
+        internal static (object, object) ResolveSchemaRegistryDeserializers(Type valueType, Type keyType, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword, string topic, IAuthenticationHeaderValueProvider authHeaderProvider = null)
         {
             object valueDeserializer = null;
             object keyDeserializer = null;
 
-            var schemaRegistry = CreateSchemaRegistry(null, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword);
+            var schemaRegistry = CreateSchemaRegistry(null, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword, authHeaderProvider);
 
             if (typeof(GenericRecord).IsAssignableFrom(valueType))
             {
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return new AvroDeserializer<TKey>(schemaRegistry).AsSyncOverAsync();
         }
 
-        internal static (object, object) ResolveSerializers(Type valueType, Type keyType, string specifiedValueAvroSchema, string specifiedKeyAvroSchema, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword, string topic)
+        internal static (object, object) ResolveSerializers(Type valueType, Type keyType, string specifiedValueAvroSchema, string specifiedKeyAvroSchema, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword, string topic, IAuthenticationHeaderValueProvider schemaRegistryAuthProvider = null)
         {
             object keySerializer = null;
             object valueSerializer = null;
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             // call helper if schema registry is specified and return avro serializers
             if (schemaRegistryUrl != null)
             {
-                return ResolveSchemaRegistrySerializers(valueType, keyType, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword, topic);
+                return ResolveSchemaRegistrySerializers(valueType, keyType, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword, topic, schemaRegistryAuthProvider);
             }
 
             // create serializers for protobuf
@@ -203,12 +203,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return (valueSerializer, keySerializer);
         }
 
-        internal static (object, object) ResolveSchemaRegistrySerializers(Type valueType, Type keyType, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword, string topic)
+        internal static (object, object) ResolveSchemaRegistrySerializers(Type valueType, Type keyType, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword, string topic, IAuthenticationHeaderValueProvider authHeaderProvider = null)
         {
             object valueSerializer = null;
             object keySerializer = null;
 
-            var schemaRegistry = CreateSchemaRegistry(null, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword); 
+            var schemaRegistry = CreateSchemaRegistry(null, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword, authHeaderProvider);
 
             if (typeof(GenericRecord).IsAssignableFrom(valueType) || typeof(ISpecificRecord).IsAssignableFrom(valueType))
             {
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         }
 
 
-        private static ISchemaRegistryClient CreateSchemaRegistry(string specifiedAvroSchema, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword)
+        private static ISchemaRegistryClient CreateSchemaRegistry(string specifiedAvroSchema, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword, IAuthenticationHeaderValueProvider authHeaderProvider = null)
         {
             if (!string.IsNullOrWhiteSpace(specifiedAvroSchema))
             {
@@ -236,9 +236,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             {
                 var schemaRegistryConfig = new List<KeyValuePair<string, string>>();
                 schemaRegistryConfig.Add(new KeyValuePair<string, string>("schema.registry.url", schemaRegistryUrl));
-                if (schemaRegistryUsername != null && schemaRegistryPassword != null) {
+                if (schemaRegistryUsername != null && schemaRegistryPassword != null)
+                {
                     var authString = schemaRegistryUsername + ":" + schemaRegistryPassword;
                     schemaRegistryConfig.Add(new KeyValuePair<string, string>("schema.registry.basic.auth.user.info", authString));
+                }
+                if (authHeaderProvider != null)
+                {
+                    return new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = schemaRegistryUrl }, authHeaderProvider);
                 }
                 return new CachedSchemaRegistryClient(schemaRegistryConfig.ToArray());
             }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaListenerConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaListenerConfiguration.cs
@@ -127,10 +127,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         /// <summary>
         /// OAuth Bearer method.
-        /// Either 'default' or 'oidc'
-        /// sasl.oauthbearer in librdkafka
+        /// One of <c>Default</c>, <c>Oidc</c>, or <c>OidcManaged</c>.
+        /// The first two map directly onto librdkafka's <c>sasl.oauthbearer.method</c>;
+        /// <c>OidcManaged</c> bypasses librdkafka's libcurl-based OIDC flow and
+        /// performs token acquisition in managed .NET code.
         /// </summary>
-        public SaslOauthbearerMethod SaslOAuthBearerMethod { get; set; }
+        public OAuthBearerMethod SaslOAuthBearerMethod { get; set; }
 
         /// <summary>
         /// OAuth Bearer Client Id

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Confluent.Kafka;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.Config;
 using Microsoft.Azure.WebJobs.Extensions.Kafka.Trigger;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -57,7 +58,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             var schemaRegistryUsername = this.config.ResolveSecureSetting(nameResolver, attribute.SchemaRegistryUsername);
             var schemaRegistryPassword = this.config.ResolveSecureSetting(nameResolver, attribute.SchemaRegistryPassword);
             var topic = this.config.ResolveSecureSetting(nameResolver, attribute.Topic);
-            (var valueDeserializer, var keyDeserializer) = SerializationHelper.ResolveDeserializers(keyAndValueTypes, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword, topic);
+
+            Confluent.SchemaRegistry.IAuthenticationHeaderValueProvider schemaRegistryAuthProvider = null;
+            if (attribute.AuthenticationMode == BrokerAuthenticationMode.OAuthBearer &&
+                OidcManagedAuth.IsManaged(attribute.OAuthBearerMethod))
+            {
+                var tokenProvider = OidcManagedAuth.CreateProvider(
+                    this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerTokenEndpointUrl),
+                    this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerClientId),
+                    this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerClientSecret),
+                    this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerScope),
+                    this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerExtensions));
+                schemaRegistryAuthProvider = new OidcAuthenticationHeaderValueProvider(tokenProvider);
+            }
+
+            (var valueDeserializer, var keyDeserializer) = SerializationHelper.ResolveDeserializers(keyAndValueTypes, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword, topic, schemaRegistryAuthProvider);
             var consumerConfig = CreateConsumerConfiguration(attribute);
             var binding = CreateBindingStrategyFor(keyAndValueTypes.KeyType ?? typeof(Ignore), keyAndValueTypes.ValueType, keyAndValueTypes.RequiresKey, valueDeserializer, keyDeserializer, parameter, consumerConfig);
             return Task.FromResult<ITriggerBinding>(new KafkaTriggerBindingWrapper(binding));
@@ -134,7 +149,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
                 if (attribute.AuthenticationMode == BrokerAuthenticationMode.OAuthBearer)
                 {
-                    consumerConfig.SaslOAuthBearerMethod = (SaslOauthbearerMethod)attribute.OAuthBearerMethod;
+                    consumerConfig.SaslOAuthBearerMethod = attribute.OAuthBearerMethod;
                     consumerConfig.SaslOAuthBearerClientId = this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerClientId);
                     consumerConfig.SaslOAuthBearerClientSecret = this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerClientSecret);
                     consumerConfig.SaslOAuthBearerScope = this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerScope);

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
@@ -600,7 +600,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(SaslMechanism.OAuthBearer, result.SaslMechanism);
             Assert.Equal("secret", result.SaslOAuthBearerClientSecret);
             Assert.Equal("clientId", result.SaslOAuthBearerClientId);
-            Assert.Equal(SaslOauthbearerMethod.Oidc, result.SaslOAuthBearerMethod);
+            Assert.Equal(Config.OAuthBearerMethod.Oidc, result.SaslOAuthBearerMethod);
             Assert.Equal("scope", result.SaslOAuthBearerScope);
             Assert.Equal("key=value", result.SaslOAuthBearerExtensions);
             Assert.Equal("endpointUrl", result.SaslOAuthBearerTokenEndpointUrl);
@@ -651,7 +651,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(SaslMechanism.OAuthBearer, result.SaslMechanism);
             Assert.Equal("secret", result.SaslOAuthBearerClientSecret);
             Assert.Equal("clientId", result.SaslOAuthBearerClientId);
-            Assert.Equal(SaslOauthbearerMethod.Oidc, result.SaslOAuthBearerMethod);
+            Assert.Equal(Config.OAuthBearerMethod.Oidc, result.SaslOAuthBearerMethod);
             Assert.Equal("scope", result.SaslOAuthBearerScope);
             Assert.Equal("key=value", result.SaslOAuthBearerExtensions);
             Assert.Equal("endpointUrl", result.SaslOAuthBearerTokenEndpointUrl);

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/OidcManagedAuthTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/OidcManagedAuthTest.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Extensions.Kafka.Config;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    public class OidcManagedAuthTest
+    {
+        [Fact]
+        public void IsManaged_ReturnsTrue_OnlyForOidcManaged()
+        {
+            Assert.False(OidcManagedAuth.IsManaged(OAuthBearerMethod.Default));
+            Assert.False(OidcManagedAuth.IsManaged(OAuthBearerMethod.Oidc));
+            Assert.True(OidcManagedAuth.IsManaged(OAuthBearerMethod.OidcManaged));
+        }
+
+        [Fact]
+        public void CreateProvider_Throws_WhenRequiredFieldsMissing()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                OidcManagedAuth.CreateProvider(null, "id", "secret", "scope", null));
+            Assert.Throws<ArgumentException>(() =>
+                OidcManagedAuth.CreateProvider("https://example/token", null, "secret", "scope", null));
+            Assert.Throws<ArgumentException>(() =>
+                OidcManagedAuth.CreateProvider("https://example/token", "id", null, "scope", null));
+        }
+
+        [Fact]
+        public void CreateProvider_AcceptsAllRequiredFields()
+        {
+            var provider = OidcManagedAuth.CreateProvider(
+                "https://example/token", "id", "secret", "scope", "a=1,b=2");
+            Assert.Equal("id", provider.PrincipalName);
+            Assert.Equal(2, provider.Extensions.Count);
+            Assert.Equal("1", provider.Extensions["a"]);
+            Assert.Equal("2", provider.Extensions["b"]);
+        }
+    }
+
+    public class OidcTokenProviderParseExtensionsTest
+    {
+        [Fact]
+        public void ParseExtensions_NullOrEmpty_ReturnsEmpty()
+        {
+            Assert.Empty(OidcTokenProvider.ParseExtensions(null));
+            Assert.Empty(OidcTokenProvider.ParseExtensions(string.Empty));
+            Assert.Empty(OidcTokenProvider.ParseExtensions("   "));
+        }
+
+        [Fact]
+        public void ParseExtensions_SinglePair_Parses()
+        {
+            var result = OidcTokenProvider.ParseExtensions("key=value");
+            Assert.Single(result);
+            Assert.Equal("value", result["key"]);
+        }
+
+        [Fact]
+        public void ParseExtensions_ConfluentCloudShape_Parses()
+        {
+            var result = OidcTokenProvider.ParseExtensions("logicalCluster=lkc-abc,identityPoolId=pool-xyz");
+            Assert.Equal(2, result.Count);
+            Assert.Equal("lkc-abc", result["logicalCluster"]);
+            Assert.Equal("pool-xyz", result["identityPoolId"]);
+        }
+
+        [Fact]
+        public void ParseExtensions_PreservesEqualsInValue()
+        {
+            var result = OidcTokenProvider.ParseExtensions("claim=foo=bar");
+            Assert.Single(result);
+            Assert.Equal("foo=bar", result["claim"]);
+        }
+
+        [Fact]
+        public void ParseExtensions_IgnoresWhitespaceBetweenEntries()
+        {
+            var result = OidcTokenProvider.ParseExtensions(" a=1 , b=2 ");
+            Assert.Equal(2, result.Count);
+            Assert.Equal("1", result["a"]);
+            Assert.Equal("2", result["b"]);
+        }
+
+        [Theory]
+        [InlineData("missingEquals")]
+        [InlineData("=valueWithoutKey")]
+        [InlineData("keyWithoutValue=")]
+        public void ParseExtensions_Throws_OnMalformedEntry(string input)
+        {
+            Assert.Throws<ArgumentException>(() => OidcTokenProvider.ParseExtensions(input));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `OAuthBearerMethod.OidcManaged` value that performs OIDC client-credentials token acquisition in managed .NET code (`HttpClient`) and pushes the token onto librdkafka via `SetOAuthBearerTokenRefreshHandler` plus a synchronous `PrimeToken` call right after `Build()`. Existing `Default` and `Oidc` behavior is unchanged.

The same `OidcTokenProvider` is reused by `Confluent.SchemaRegistry`'s `IAuthenticationHeaderValueProvider`, so the SR client uses the same access token.

Wired at four sites: `KafkaListener` (consumer), `KafkaScalerProvider` (scaler consumer), `KafkaMetricsProvider.LoadTopicPartitions` (single-shot AdminClient), and `KafkaProducerFactory` (producer + SR client).

## Motivation

Two problems on Linux in Azure Functions Flex Consumption (and similar Linux images that don't ship the RHEL-style CA bundle path):

**1. librdkafka's built-in OIDC path uses libcurl, which on these images hits**

```
error setting certificate file: /etc/pki/tls/certs/ca-bundle.crt (-1)
```

The path is hardcoded into libcurl at compile time. The natural fix would be to set `https.ca.location` on the producer/consumer config, but **that property was only added in librdkafka v2.11.0**. `Confluent.Kafka 2.4.0` (this extension's pinned version) ships a librdkafka that does not expose it, so we cannot wire it from managed code without bumping the Confluent.Kafka dependency — a much larger change.

Performing the token fetch in managed .NET sidesteps libcurl entirely. `HttpClient` uses the OS trust store on every supported platform, so the CA-bundle problem disappears.

**2. The refresh-handler callback only fires when the client is actively polled**

`SetOAuthBearerTokenRefreshHandler` is dispatched during `Consume()` / `Poll()`. Single-shot clients (the scaler's `IConsumer` + `AdminClient`) never poll — they make synchronous `Committed` / `QueryWatermarkOffsets` / `GetMetadata` calls. Without polling, the callback never fires, no token is set, and librdkafka blocks the broker thread in `TRY_CONNECT` indefinitely.

`PrimeToken` is a synchronous call applied right after `.Build()` on every client (listener, scaler, producer, AdminClient). It calls the same managed token-fetch path the refresh handler would call, then `IClient.OAuthBearerSetToken(token, expiresAtUnixMs, principal, extensions)`. The broker can complete its handshake before any I/O. The refresh handler stays registered for subsequent rotations.

## Design

- New enum value `OAuthBearerMethod.OidcManaged` (alongside `Default` and `Oidc`); existing values unchanged.
- `OidcTokenProvider` — thread-safe HTTP token cache (`SemaphoreSlim` + double-check), caches token until `expires_at - 60s`, refreshes on demand. Targets netstandard2.0, so `Newtonsoft.Json.Linq.JObject` for the response parse instead of `System.Text.Json` (avoids a new dep).
- `OidcManagedAuth` — static helpers: `IsManaged`, `CreateProvider`, `WireConsumer`/`WireProducer`/`WireAdminClient`, `PrimeToken`. Same `RefreshToken` body for both proactive prime and reactive refresh.
- `OidcAuthenticationHeaderValueProvider` — `IAuthenticationHeaderValueProvider` adapter that uses the same `OidcTokenProvider`, so the Schema Registry client shares the access token.
- `Information`-level diagnostic logs around acquire / fetch / set so operators can verify each phase from telemetry without enabling librdkafka debug.

The conditional skip of the upstream OAUTHBEARER config (in `KafkaListener`, `KafkaProducerFactory`, `KafkaScalerProvider`, `KafkaTriggerAttributeBindingProvider`) prevents librdkafka from ALSO trying its built-in OIDC path when `OidcManaged` is selected — only the managed path runs, no double-init.

## Why not bump Confluent.Kafka and use `https.ca.location`?

`https.ca.location` (added in librdkafka 2.11) would let us configure the CA bundle from managed code without changing the auth flow. But:

- Bumping `Confluent.Kafka` from `2.4.0` ripples through `Confluent.SchemaRegistry`, `Confluent.SchemaRegistry.Serdes.Avro/Protobuf`, and the broader binding/serializer surface.
- librdkafka 2.11 has its own list of behavioral changes, some breaking, that need separate validation.
- The managed-token approach works on existing librdkafka 2.4 *and* gives operators a clean .NET-side token lifecycle (cacheable, observable, testable) — independent of any future librdkafka upgrade.

If/when this extension does eventually bump to librdkafka 2.11+, `OidcManaged` continues to work unchanged, and `Oidc` users can additionally configure `https.ca.location` if they prefer the built-in path.

## Operational note for Flex Consumption: Always-Ready is still required

This PR fixes the **listener** side. End-to-end auto-scaling on Flex Consumption needs an additional change on the platform side that is out of this repo's scope.

Per [Architecture.md § Scale Controller Integration](https://github.com/Azure/azure-functions-kafka-extension/blob/dev/Architecture.md#scale-controller-integration), Azure's Functions Scale Controller (separate repo `AAPT-Antares-ScaleController`) embeds a pinned NuGet reference to this extension and uses reflection to invoke `AddKafkaScaleForTrigger` for scaling decisions. Until the Scale Controller's reference is bumped to a release that contains `OidcManaged`, the Scale Controller can't compute lag for triggers that use this method — function metadata serializes as `OAuthBearerMethod: "OidcManaged"` (enum value 2), which doesn't deserialize cleanly into the Scale Controller's older `SaslOauthbearerMethod`.

The operational consequence: on Flex, deployments using `OidcManaged` need `alwaysReady` set on the Kafka function group(s) to keep at least one instance hosting the listener. Configure via the function app's `scaleAndConcurrency.alwaysReady`:

```bash
az functionapp scale config always-ready set \
  --resource-group <rg> --name <app> \
  --settings function:myKafkaTriggerFunction=1
```

Once a Kafka extension release containing `OidcManaged` makes it into the Scale Controller's pinned version, dynamic scale-from-zero will work without `alwaysReady`.

## Test plan

- [x] All 236 unit tests pass (225 pre-existing + 11 new in `OidcManagedAuthTest`)
- [x] Build clean, zero warnings on `Microsoft.Azure.WebJobs.Extensions.Kafka.csproj` and the test project
- [x] Verified end-to-end on Azure Functions Flex Consumption (Linux, isolated worker, byte[][] batched trigger) against Confluent Cloud OIDC + Schema Registry (Avro), with `alwaysReady=1` set: listener consumes events, OIDC chain logs as expected, broker reaches `UP` state cleanly without the libcurl CA failure.
- [ ] Reviewer to validate StyleCop / `TreatWarningsAsErrors` on CI (passes locally)

## Files

```
Architecture.md                                                        +2/-0   (scale-aware paths note)
lint-architecture.ps1                                                  +5/-0   (CFK-001 allow-list entries)
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OAuthBearerMethod.cs
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OidcAuthenticationHeaderValueProvider.cs   (new)
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OidcManagedAuth.cs                         (new)
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/OidcTokenProvider.cs                       (new)
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaMetricsProvider.cs
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaScalerProvider.cs
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/SerializationHelper.cs
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaListenerConfiguration.cs
src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/OidcManagedAuthTest.cs                 (new)
```

## Companion PR

Worker-side enum addition: Azure/azure-functions-dotnet-worker — adds `OAuthBearerMethod.OidcManaged` value to `Microsoft.Azure.Functions.Worker.Extensions.Kafka` so the isolated-worker `[KafkaTrigger]` attribute can carry the new value.
