### PR TITLE
Remove LeaderEpoch from KafkaRecord protobuf transport

### DIFF
--- a/docs/KafkaRecord-Design.md
+++ b/docs/KafkaRecord-Design.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-`KafkaRecord` is a new binding type that gives Azure Functions users access to the complete Apache Kafka record metadata — topic, partition, offset, key (raw bytes), value (raw bytes), headers, timestamp, and leader epoch — without coupling to the Confluent.Kafka library.
+`KafkaRecord` is a new binding type that gives Azure Functions users access to the complete Apache Kafka record metadata — topic, partition, offset, key (raw bytes), value (raw bytes), headers, and timestamp — without coupling to the Confluent.Kafka library.
 
 Users opt in by changing their function parameter type. Existing bindings (`string`, `byte[]`, `KafkaEventData<T>`) are completely unaffected.
 
@@ -54,6 +54,7 @@ Based on customer feedback ([#612 discussion](https://github.com/Azure/azure-fun
 | **No generics** — Key and Value are `byte[]` | User controls deserialization; supports any schema strategy |
 | **Apache Kafka spec-aligned** | Fields match the Kafka protocol record definition |
 | **`IsPartitionEOF` excluded** | Consumer state, not record metadata |
+| **`LeaderEpoch` excluded** | Consumer fetch metadata, not stored record data ([#639](https://github.com/Azure/azure-functions-kafka-extension/issues/639)) |
 | **Protobuf serialization** | Zero Base64 overhead for binary key/value transport |
 | **Opt-in via parameter type** | No configuration changes; existing code unaffected |
 
@@ -102,7 +103,8 @@ message KafkaRecordProto {
     bytes value = 5;            // native bytes, zero overhead
     KafkaTimestampProto timestamp = 6;
     repeated KafkaHeaderProto headers = 7;
-    optional int32 leader_epoch = 8;
+    reserved 8;                 // leader_epoch removed (issue #639)
+    reserved "leader_epoch";
 }
 ```
 

--- a/docs/KafkaRecord-Design.md
+++ b/docs/KafkaRecord-Design.md
@@ -99,8 +99,8 @@ message KafkaRecordProto {
     string topic = 1;
     int32 partition = 2;
     int64 offset = 3;
-    bytes key = 4;              // native bytes, zero overhead
-    bytes value = 5;            // native bytes, zero overhead
+    optional bytes key = 4;     // native bytes, zero overhead
+    optional bytes value = 5;   // native bytes, zero overhead
     KafkaTimestampProto timestamp = 6;
     repeated KafkaHeaderProto headers = 7;
     reserved 8;                 // leader_epoch removed (issue #639)

--- a/samples/dotnet/KafkaRecordTransportSmoke/KafkaRecordTransportSmokeFunctions.cs
+++ b/samples/dotnet/KafkaRecordTransportSmoke/KafkaRecordTransportSmokeFunctions.cs
@@ -65,8 +65,7 @@ namespace KafkaRecordTransportSmoke
                 Value = value,
                 TimestampUnixMs = proto.Timestamp?.UnixTimestampMs ?? 0,
                 TimestampType = proto.Timestamp?.Type ?? 0,
-                HeaderCount = proto.Headers.Count,
-                LeaderEpoch = proto.HasLeaderEpoch ? proto.LeaderEpoch : (int?)null
+                HeaderCount = proto.Headers.Count
             };
 
             ReceivedRecords.Enqueue(record);
@@ -127,7 +126,5 @@ namespace KafkaRecordTransportSmoke
         public int TimestampType { get; set; }
 
         public int HeaderCount { get; set; }
-
-        public int? LeaderEpoch { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProto.proto
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProto.proto
@@ -16,7 +16,11 @@ message KafkaRecordProto {
     optional bytes value = 5;
     KafkaTimestampProto timestamp = 6;
     repeated KafkaHeaderProto headers = 7;
-    optional int32 leader_epoch = 8;
+
+    // leader_epoch was removed per customer feedback (issue #639).
+    // It represents consumer fetch metadata, not stored record data.
+    reserved 8;
+    reserved "leader_epoch";
 
     // Reserved for future fields. Do not reuse field numbers.
     reserved 9 to 15;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProtobufSerializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProtobufSerializer.cs
@@ -55,10 +55,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization
                 proto.Value = ToByteString(eventData.Value);
             }
 
-            if (eventData.LeaderEpoch.HasValue)
-            {
-                proto.LeaderEpoch = eventData.LeaderEpoch.Value;
-            }
+            // LeaderEpoch intentionally not serialized into KafkaRecordProto.
+            // It is consumer fetch metadata, not stored record data (issue #639).
 
             if (eventData.Headers != null)
             {

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaEventDataConvertManagerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaEventDataConvertManagerTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
-using Google.Protobuf;
 using Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -57,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("1.0", bindingData.Version);
             Assert.Equal(KafkaRecordProtobufSerializer.BindingSource, bindingData.Source);
             Assert.Equal(KafkaRecordProtobufSerializer.ContentType, bindingData.ContentType);
-            Assert.False(ContainsTopLevelField(bindingData.Content.ToArray(), 8));
+            Assert.False(ProtobufTestHelpers.ContainsTopLevelField(bindingData.Content.ToArray(), 8));
 
             // Verify content is valid Protobuf with expected fields
             var proto = KafkaRecordProto.Parser.ParseFrom(bindingData.Content);
@@ -88,24 +87,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var manager = new KafkaEventDataConvertManager(NullLogger.Instance);
             var converter = manager.GetConverter<KafkaTriggerAttribute>(typeof(IKafkaEventData), typeof(byte[]));
             Assert.NotNull(converter);
-        }
-
-        private static bool ContainsTopLevelField(byte[] bytes, int fieldNumber)
-        {
-            var input = new CodedInputStream(bytes);
-            uint tag;
-
-            while ((tag = input.ReadTag()) != 0)
-            {
-                if (WireFormat.GetTagFieldNumber(tag) == fieldNumber)
-                {
-                    return true;
-                }
-
-                input.SkipLastField();
-            }
-
-            return false;
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaEventDataConvertManagerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaEventDataConvertManagerTest.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("test-topic", proto.Topic);
             Assert.Equal(3, proto.Partition);
             Assert.Equal(42L, proto.Offset);
-            Assert.Equal(5, proto.LeaderEpoch);
+            // LeaderEpoch intentionally not serialized into KafkaRecordProto (issue #639)
             Assert.Equal("test-key", Encoding.UTF8.GetString(proto.Key.ToByteArray()));
             Assert.Equal("test-value", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaEventDataConvertManagerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaEventDataConvertManagerTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using Google.Protobuf;
 using Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -56,6 +57,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("1.0", bindingData.Version);
             Assert.Equal(KafkaRecordProtobufSerializer.BindingSource, bindingData.Source);
             Assert.Equal(KafkaRecordProtobufSerializer.ContentType, bindingData.ContentType);
+            Assert.False(ContainsTopLevelField(bindingData.Content.ToArray(), 8));
 
             // Verify content is valid Protobuf with expected fields
             var proto = KafkaRecordProto.Parser.ParseFrom(bindingData.Content);
@@ -86,6 +88,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var manager = new KafkaEventDataConvertManager(NullLogger.Instance);
             var converter = manager.GetConverter<KafkaTriggerAttribute>(typeof(IKafkaEventData), typeof(byte[]));
             Assert.NotNull(converter);
+        }
+
+        private static bool ContainsTopLevelField(byte[] bytes, int fieldNumber)
+        {
+            var input = new CodedInputStream(bytes);
+            uint tag;
+
+            while ((tag = input.ReadTag()) != 0)
+            {
+                if (WireFormat.GetTagFieldNumber(tag) == fieldNumber)
+                {
+                    return true;
+                }
+
+                input.SkipLastField();
+            }
+
+            return false;
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaRecordProtobufSerializerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaRecordProtobufSerializerTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Text;
-using Google.Protobuf;
 using Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization;
 using Xunit;
 
@@ -54,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             };
 
             var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
-            Assert.False(ContainsTopLevelField(bytes, 8));
+            Assert.False(ProtobufTestHelpers.ContainsTopLevelField(bytes, 8));
 
             var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
 
@@ -211,24 +210,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Single(proto.Headers);
             Assert.Equal("nullHeader", proto.Headers[0].Key);
             Assert.True(proto.Headers[0].Value.IsEmpty);
-        }
-
-        private static bool ContainsTopLevelField(byte[] bytes, int fieldNumber)
-        {
-            var input = new CodedInputStream(bytes);
-            uint tag;
-
-            while ((tag = input.ReadTag()) != 0)
-            {
-                if (WireFormat.GetTagFieldNumber(tag) == fieldNumber)
-                {
-                    return true;
-                }
-
-                input.SkipLastField();
-            }
-
-            return false;
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaRecordProtobufSerializerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaRecordProtobufSerializerTest.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("test-topic", proto.Topic);
             Assert.Equal(3, proto.Partition);
             Assert.Equal(42, proto.Offset);
-            Assert.Equal(7, proto.LeaderEpoch);
-            Assert.True(proto.HasLeaderEpoch);
             Assert.Equal("myKey", Encoding.UTF8.GetString(proto.Key.ToByteArray()));
             Assert.Equal("myValue", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
             Assert.NotNull(proto.Timestamp);
@@ -41,21 +39,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         [Fact]
-        public void Serialize_NullLeaderEpoch_OmitsField()
+        public void Serialize_LeaderEpoch_NotIncludedInProtobuf()
         {
+            // LeaderEpoch is consumer fetch metadata, not stored record data (issue #639).
+            // Even when set on IKafkaEventData, it should NOT appear in the Protobuf output.
             var eventData = new KafkaEventData<string, string>("key", "value")
             {
                 Offset = 1,
                 Partition = 0,
                 Topic = "topic",
                 Timestamp = DateTime.UtcNow,
-                LeaderEpoch = null,
+                LeaderEpoch = 42,
             };
 
             var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
             var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
 
-            Assert.False(proto.HasLeaderEpoch);
+            // Protobuf schema no longer has leader_epoch field.
+            // Verify the record still round-trips correctly without it.
+            Assert.Equal("topic", proto.Topic);
+            Assert.Equal(0, proto.Partition);
+            Assert.Equal(1, proto.Offset);
         }
 
         [Fact]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaRecordProtobufSerializerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaRecordProtobufSerializerTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text;
+using Google.Protobuf;
 using Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization;
 using Xunit;
 
@@ -53,6 +54,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             };
 
             var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+            Assert.False(ContainsTopLevelField(bytes, 8));
+
             var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
 
             // Protobuf schema no longer has leader_epoch field.
@@ -208,6 +211,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Single(proto.Headers);
             Assert.Equal("nullHeader", proto.Headers[0].Key);
             Assert.True(proto.Headers[0].Value.IsEmpty);
+        }
+
+        private static bool ContainsTopLevelField(byte[] bytes, int fieldNumber)
+        {
+            var input = new CodedInputStream(bytes);
+            uint tag;
+
+            while ((tag = input.ReadTag()) != 0)
+            {
+                if (WireFormat.GetTagFieldNumber(tag) == fieldNumber)
+                {
+                    return true;
+                }
+
+                input.SkipLastField();
+            }
+
+            return false;
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/ProtobufTestHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/ProtobufTestHelpers.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Google.Protobuf;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    internal static class ProtobufTestHelpers
+    {
+        internal static bool ContainsTopLevelField(byte[] bytes, int fieldNumber)
+        {
+            var input = new CodedInputStream(bytes);
+            uint tag;
+
+            while ((tag = input.ReadTag()) != 0)
+            {
+                if (WireFormat.GetTagFieldNumber(tag) == fieldNumber)
+                {
+                    return true;
+                }
+
+                input.SkipLastField();
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Remove `LeaderEpoch` from the `KafkaRecord` Protobuf transport schema before release, per customer feedback in #639.

`LeaderEpoch` represents consumer fetch/offset metadata (exposed by `ConsumeResult.LeaderEpoch` / `TopicPartitionOffset.LeaderEpoch` in Confluent.Kafka), not stored Kafka record data. Since `KafkaRecord` is intended to represent the record payload and record metadata, `LeaderEpoch` does not belong on this type.

## Changes

### Protobuf schema
- Removed `leader_epoch` (field 8) from `KafkaRecordProto`
- Reserved field number 8 and name `leader_epoch` to prevent future accidental reuse

### Serializer
- Removed `LeaderEpoch` serialization from `KafkaRecordProtobufSerializer`

### Tests
- Replaced `LeaderEpoch` presence assertions with exclusion verification test
- Updated `KafkaEventDataConvertManagerTest` to remove `LeaderEpoch` assertion on proto output

### Smoke sample
- Removed `LeaderEpoch` from `ReceivedKafkaRecord` DTO

### Design doc
- Added `LeaderEpoch` exclusion rationale to the design decisions table

## NOT changed (backward compatibility)

The following existing APIs are preserved with NO breaking changes:

- `IKafkaEventData.LeaderEpoch` - existing interface property
- `KafkaEventData.LeaderEpoch` - existing class property
- `KafkaRecordSerializer` (JSON path) - existing serialization
- `KafkaTriggerBindingStrategy` - trigger metadata binding
- All existing trigger metadata tests

## Testing

- Unit tests: 227/227 passed
- E2E tests: 37/37 passed (including KafkaRecord Protobuf metadata verification for topic, partition, offset, timestamp, headers, key, value)
- Architecture linter: 0 errors, 0 warnings

Closes #639