### PR TITLE
[Release] 4.3.2

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -49,6 +49,12 @@ steps:
       version: 6.x
       packageType: sdk
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET 8.0'
+    inputs:
+      version: 8.x
+      packageType: sdk
+
   - task: DotNetCoreCLI@2
     displayName: Build project
     inputs:

--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>4.3.1</Version>
+    <Version>4.3.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>

--- a/docs/KafkaRecord-Design.md
+++ b/docs/KafkaRecord-Design.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-`KafkaRecord` is a new binding type that gives Azure Functions users access to the complete Apache Kafka record metadata — topic, partition, offset, key (raw bytes), value (raw bytes), headers, timestamp, and leader epoch — without coupling to the Confluent.Kafka library.
+`KafkaRecord` is a new binding type that gives Azure Functions users access to the complete Apache Kafka record metadata — topic, partition, offset, key (raw bytes), value (raw bytes), headers, and timestamp — without coupling to the Confluent.Kafka library.
 
 Users opt in by changing their function parameter type. Existing bindings (`string`, `byte[]`, `KafkaEventData<T>`) are completely unaffected.
 
@@ -54,6 +54,7 @@ Based on customer feedback ([#612 discussion](https://github.com/Azure/azure-fun
 | **No generics** — Key and Value are `byte[]` | User controls deserialization; supports any schema strategy |
 | **Apache Kafka spec-aligned** | Fields match the Kafka protocol record definition |
 | **`IsPartitionEOF` excluded** | Consumer state, not record metadata |
+| **`LeaderEpoch` excluded** | Consumer fetch metadata, not stored record data ([#639](https://github.com/Azure/azure-functions-kafka-extension/issues/639)) |
 | **Protobuf serialization** | Zero Base64 overhead for binary key/value transport |
 | **Opt-in via parameter type** | No configuration changes; existing code unaffected |
 
@@ -98,11 +99,12 @@ message KafkaRecordProto {
     string topic = 1;
     int32 partition = 2;
     int64 offset = 3;
-    bytes key = 4;              // native bytes, zero overhead
-    bytes value = 5;            // native bytes, zero overhead
+    optional bytes key = 4;     // native bytes, zero overhead
+    optional bytes value = 5;   // native bytes, zero overhead
     KafkaTimestampProto timestamp = 6;
     repeated KafkaHeaderProto headers = 7;
-    optional int32 leader_epoch = 8;
+    reserved 8;                 // leader_epoch removed (issue #639)
+    reserved "leader_epoch";
 }
 ```
 

--- a/eng/cd/templates/approve.yml
+++ b/eng/cd/templates/approve.yml
@@ -8,8 +8,8 @@ jobs:
       - task: ManualValidation@1
         inputs:
           notifyUsers: |-
-            [TEAM FOUNDATION]\Azure Functions IDC
+            [TEAM FOUNDATION]\Varad Meru's Team
           approvers: |-
-            [TEAM FOUNDATION]\Azure Functions IDC
+            [TEAM FOUNDATION]\Varad Meru's Team
           allowApproversToApproveTheirOwnRuns: false
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProto.proto
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProto.proto
@@ -16,7 +16,11 @@ message KafkaRecordProto {
     optional bytes value = 5;
     KafkaTimestampProto timestamp = 6;
     repeated KafkaHeaderProto headers = 7;
-    optional int32 leader_epoch = 8;
+
+    // leader_epoch was removed per customer feedback (issue #639).
+    // It represents consumer fetch metadata, not stored record data.
+    reserved 8;
+    reserved "leader_epoch";
 
     // Reserved for future fields. Do not reuse field numbers.
     reserved 9 to 15;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProtobufSerializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/KafkaRecordProtobufSerializer.cs
@@ -55,10 +55,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Serialization
                 proto.Value = ToByteString(eventData.Value);
             }
 
-            if (eventData.LeaderEpoch.HasValue)
-            {
-                proto.LeaderEpoch = eventData.LeaderEpoch.Value;
-            }
+            // LeaderEpoch intentionally not serialized into KafkaRecordProto.
+            // It is consumer fetch metadata, not stored record data (issue #639).
 
             if (eventData.Headers != null)
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/SerializationHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/SerializationHelper.cs
@@ -12,6 +12,7 @@ using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry;
 using Confluent.SchemaRegistry.Serdes;
 using Google.Protobuf;
+using Microsoft.Azure.WebJobs.Host.Bindings;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 {
@@ -271,6 +272,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             while (valueType.HasElementType && valueType.GetElementType() != typeof(byte))
             {
                 valueType = valueType.GetElementType();
+            }
+
+            if (valueType == typeof(ParameterBindingData))
+            {
+                valueType = typeof(byte[]);
             }
 
             if (!valueType.IsPrimitive)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
@@ -376,46 +376,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         /// Ensures that multiple hosts processing a topic with 10 partition share the content, having the events being processed at least once.
         /// 
         /// Test flow:
-        /// 1. In a separated task producer creates 4x80 items. After the first batch is created waits for semaphore.
-        /// 2. In main task host1 starts processing messages
-        /// 3. When host1 has at least a message starts hosts2
-        /// 4. When host2 obtains at least 1 partitions it triggers the semaphore
-        /// 5. Once the producer tasks is finished (all 240 messages were created), validate that all messages were processed by host1 and host2
+        /// 1. In main task host1 starts processing messages
+        /// 2. When host1 has partitions, start host2
+        /// 3. When host2 obtains at least 1 partition, produce messages evenly across all partitions
+        /// 4. Validate that all messages were processed by host1 and host2
         /// </summary>
         [Fact]
         public async Task Multiple_Hosts_Process_Events_At_Least_Once()
         {
-            const int producedMessagesCount = 240;
+            const int producedMessagesCount = 120;
+            const int waitForAllMessagesTimeoutMs = 180 * 1000;
             var messagePrefix = Guid.NewGuid().ToString() + ":";
-
-            var producerHost = await StartHostAsync(typeof(KafkaOutputFunctions));
-            var producerJobHost = producerHost.GetJobHost();
-
-            var host2HasPartitionsSemaphore = new SemaphoreSlim(0);
-
-            // Split the call in 4, waiting 1sec between calls
-            var producerTask = Task.Run(async () =>
-            {
-                var allMessages = Enumerable.Range(1, producedMessagesCount).Select(x => EndToEndTestExtensions.CreateMessageValue(messagePrefix, x));
-                const int loopCount = 4;
-                var itemsPerLoop = producedMessagesCount / loopCount;
-                for (var i = 0; i < loopCount; ++i)
-                {
-                    var messages = allMessages.Skip(i * itemsPerLoop).Take(itemsPerLoop);
-                    await producerJobHost.CallOutputTriggerStringAsync(
-                        GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                        this.endToEndTestFixture.StringTopicWithTenPartitions.Name,
-                        messages);
-
-                    if (i == 0)
-                    {
-                        // wait until host2 has partitions assigned
-                        Assert.True(await host2HasPartitionsSemaphore.WaitAsync(TimeSpan.FromSeconds(50)), "Host2 has not been assigned any partition after waiting for 30 seconds");
-                    }
-
-                    await Task.Delay(100);
-                }
-            });
 
             IHost host1 = null, host2 = null;
             Func<LogMessage, bool> messageFilter = (LogMessage m) => m.FormattedMessage != null && m.FormattedMessage.Contains(messagePrefix);
@@ -442,16 +413,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 {
                     var host2HasPartitions = host2Log.GetAllLogMessages().Any(x => x.FormattedMessage != null && x.FormattedMessage.Contains("Assigned partitions"));
 
-                    if (host2HasPartitions)
-                    {
-                        host2HasPartitionsSemaphore.Release();
-                    }
-
                     return host2HasPartitions;
                 });
 
-                // Wait until producer is finished
-                await producerTask;
+                await ProduceMessagesToAllPartitionsAsync(
+                    this.endToEndTestFixture.StringTopicWithTenPartitions.Name,
+                    Enumerable.Range(1, producedMessagesCount).Select(x => EndToEndTestExtensions.CreateMessageValue(messagePrefix, x)));
 
                 await TestHelpers.Await(() =>
                 {
@@ -461,7 +428,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     return host1Events.Count > 0 &&
                         host2Events.Count > 0 &&
                         host2Events.Count + host1Events.Count >= producedMessagesCount;
-                });
+                }, timeout: waitForAllMessagesTimeoutMs);
 
 
                 await TestHelpers.Await(() =>
@@ -481,7 +448,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     }
 
                     return true;
-                });
+                }, timeout: waitForAllMessagesTimeoutMs);
 
                 // For history write down items that have been processed more than once
                 // If an item is processed more than 2x times test fails
@@ -509,10 +476,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 await host1?.StopAsync();
                 await host2?.StopAsync();
             }
+        }
 
-            await producerTask;
-            await producerHost?.StopAsync();
+        private static Task ProduceMessagesToAllPartitionsAsync(string topicName, IEnumerable<string> messages)
+        {
+            using var producer = new Confluent.Kafka.ProducerBuilder<Confluent.Kafka.Null, string>(new Confluent.Kafka.ProducerConfig
+            {
+                BootstrapServers = "localhost:9092"
+            }).Build();
 
+            var partition = 0;
+            foreach (var message in messages)
+            {
+                producer.Produce(
+                    new Confluent.Kafka.TopicPartition(topicName, new Confluent.Kafka.Partition(partition)),
+                    new Confluent.Kafka.Message<Confluent.Kafka.Null, string>
+                    {
+                        Value = message
+                    });
+
+                partition = (partition + 1) % 10;
+            }
+
+            var remainingMessages = producer.Flush(TimeSpan.FromSeconds(30));
+            if (remainingMessages != 0)
+            {
+                throw new TimeoutException($"Kafka producer did not flush within timeout. Remaining messages: {remainingMessages}");
+            }
+
+            return Task.CompletedTask;
         }
 
         private List<KafkaEventData<string>> GetKafkaEventsWithTraceParentHeader(int numEvents)
@@ -1439,6 +1431,74 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 // Value should still be present
                 Assert.True(proto.HasValue, "Value should be set");
                 Assert.Contains("nullkey-test-", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
+            }
+        }
+
+        /// <summary>
+        /// E2E test that exercises the FULL deferred binding path for KafkaRecord.
+        /// The trigger function parameter is ParameterBindingData — the same type the
+        /// host sees when a .NET isolated worker uses KafkaRecord with SupportsDeferredBinding.
+        /// This validates that:
+        ///   1. SerializationHelper.GetKeyAndValueTypes maps ParameterBindingData → byte[]
+        ///   2. The Kafka consumer starts successfully (no deserializer error)
+        ///   3. KafkaEventDataConvertManager converts consumed events to ParameterBindingData
+        ///   4. The ParameterBindingData contains valid Protobuf with correct metadata
+        /// Without the fix, this test fails at host startup with:
+        ///   "Value deserializer was not specified and there is no default deserializer
+        ///    defined for type ParameterBindingData"
+        /// </summary>
+        [Fact]
+        public async Task KafkaRecord_DeferredBinding_ParameterBindingData_HostStartsAndReceivesProtobuf()
+        {
+            const int messageCount = 5;
+            var messagePrefix = Guid.NewGuid().ToString() + ":pbd:";
+
+            // Clear any previous test data
+            while (SingleItem_ParameterBindingData_Trigger.Received.TryTake(out _)) { }
+
+            var loggerProvider1 = CreateTestLoggerProvider();
+
+            using (var host = await StartHostAsync(
+                new[] { typeof(SingleItem_ParameterBindingData_Trigger), typeof(KafkaOutputFunctions) },
+                loggerProvider1))
+            {
+                var jobHost = host.GetJobHost();
+
+                // Produce messages via the existing KafkaOutputFunctions
+                await jobHost.CallOutputTriggerStringAsync(
+                    GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
+                    endToEndTestFixture.StringTopicWithTenPartitions.Name,
+                    Enumerable.Range(1, messageCount).Select(x => messagePrefix + x));
+
+                // Wait for the trigger to receive all messages as ParameterBindingData
+                await TestHelpers.Await(() =>
+                    SingleItem_ParameterBindingData_Trigger.Received.Count >= messageCount);
+            }
+
+            // Validate received ParameterBindingData
+            var received = SingleItem_ParameterBindingData_Trigger.Received.ToList();
+            Assert.True(received.Count >= messageCount,
+                $"Expected at least {messageCount} ParameterBindingData items, got {received.Count}");
+
+            foreach (var bindingData in received)
+            {
+                // Source and content type must match the KafkaRecord deferred binding contract
+                Assert.Equal("AzureKafkaRecord", bindingData.Source);
+                Assert.Equal("application/x-protobuf", bindingData.ContentType);
+
+                // Content must be valid Protobuf
+                var proto = KafkaRecordProto.Parser.ParseFrom(bindingData.Content);
+
+                // Broker-assigned metadata is populated
+                Assert.Equal(Constants.StringTopicWithTenPartitionsName, proto.Topic);
+                Assert.True(proto.Partition >= 0, "Partition should be >= 0");
+                Assert.True(proto.Offset >= 0, "Offset should be >= 0");
+                Assert.NotNull(proto.Timestamp);
+                Assert.True(proto.Timestamp.UnixTimestampMs > 0, "Timestamp should be > 0");
+
+                // Value is the produced string
+                Assert.True(proto.HasValue, "Value should be set");
+                Assert.Contains(messagePrefix, Encoding.UTF8.GetString(proto.Value.ToByteArray()));
             }
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/TriggerFunctions.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/TriggerFunctions.cs
@@ -9,6 +9,7 @@ using System.Reflection.Emit;
 using System.Text;
 using Avro.Generic;
 using Confluent.Kafka;
+using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
@@ -422,6 +423,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var value = kafkaEvent.Value.ToString();
             log.LogInformation("AtLeastOnce_AlwaysFail for {value}", value);
             throw new InvalidOperationException($"Permanent failure for: {value}");
+        }
+    }
+
+    /// <summary>
+    /// Trigger function that binds to ParameterBindingData — simulates the host-side
+    /// parameter type seen during .NET isolated deferred binding for KafkaRecord.
+    /// Without the ParameterBindingData → byte[] fix in SerializationHelper,
+    /// the host fails at startup with "no default deserializer for ParameterBindingData".
+    /// </summary>
+    internal static class SingleItem_ParameterBindingData_Trigger
+    {
+        public static ConcurrentBag<ParameterBindingData> Received = new ConcurrentBag<ParameterBindingData>();
+
+        public static void Trigger(
+            [KafkaTrigger("LocalBroker", Constants.StringTopicWithTenPartitionsName, ConsumerGroup = Constants.ConsumerGroupID)] ParameterBindingData bindingData,
+            ILogger log)
+        {
+            Received.Add(bindingData);
+            log.LogInformation("ParameterBindingData received: source={source}", bindingData.Source);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AtLeastOnceDeliveryTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         /// <summary>
         /// Default timeout for all async waits. Long enough for slow CI, short enough to fail fast.
         /// </summary>
-        private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
 
         private ConsumeResult<TKey, TValue> CreateConsumeResult<TKey, TValue>(TValue value, int partition, long offset, string topic = "topic")
         {

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaEventDataConvertManagerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaEventDataConvertManagerTest.cs
@@ -56,13 +56,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("1.0", bindingData.Version);
             Assert.Equal(KafkaRecordProtobufSerializer.BindingSource, bindingData.Source);
             Assert.Equal(KafkaRecordProtobufSerializer.ContentType, bindingData.ContentType);
+            Assert.False(ProtobufTestHelpers.ContainsTopLevelField(bindingData.Content.ToArray(), 8));
 
             // Verify content is valid Protobuf with expected fields
             var proto = KafkaRecordProto.Parser.ParseFrom(bindingData.Content);
             Assert.Equal("test-topic", proto.Topic);
             Assert.Equal(3, proto.Partition);
             Assert.Equal(42L, proto.Offset);
-            Assert.Equal(5, proto.LeaderEpoch);
+            // LeaderEpoch intentionally not serialized into KafkaRecordProto (issue #639)
             Assert.Equal("test-key", Encoding.UTF8.GetString(proto.Key.ToByteArray()));
             Assert.Equal("test-value", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaRecordProtobufSerializerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaRecordProtobufSerializerTest.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("test-topic", proto.Topic);
             Assert.Equal(3, proto.Partition);
             Assert.Equal(42, proto.Offset);
-            Assert.Equal(7, proto.LeaderEpoch);
-            Assert.True(proto.HasLeaderEpoch);
             Assert.Equal("myKey", Encoding.UTF8.GetString(proto.Key.ToByteArray()));
             Assert.Equal("myValue", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
             Assert.NotNull(proto.Timestamp);
@@ -41,21 +39,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         [Fact]
-        public void Serialize_NullLeaderEpoch_OmitsField()
+        public void Serialize_LeaderEpoch_NotIncludedInProtobuf()
         {
+            // LeaderEpoch is consumer fetch metadata, not stored record data (issue #639).
+            // Even when set on IKafkaEventData, it should NOT appear in the Protobuf output.
             var eventData = new KafkaEventData<string, string>("key", "value")
             {
                 Offset = 1,
                 Partition = 0,
                 Topic = "topic",
                 Timestamp = DateTime.UtcNow,
-                LeaderEpoch = null,
+                LeaderEpoch = 42,
             };
 
             var bytes = KafkaRecordProtobufSerializer.Serialize(eventData);
+            Assert.False(ProtobufTestHelpers.ContainsTopLevelField(bytes, 8));
+
             var proto = KafkaRecordProto.Parser.ParseFrom(bytes);
 
-            Assert.False(proto.HasLeaderEpoch);
+            // Protobuf schema no longer has leader_epoch field.
+            // Verify the record still round-trips correctly without it.
+            Assert.Equal("topic", proto.Topic);
+            Assert.Equal(0, proto.Partition);
+            Assert.Equal(1, proto.Offset);
         }
 
         [Fact]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/ProtobufTestHelpers.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/ProtobufTestHelpers.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Google.Protobuf;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    internal static class ProtobufTestHelpers
+    {
+        internal static bool ContainsTopLevelField(byte[] bytes, int fieldNumber)
+        {
+            var input = new CodedInputStream(bytes);
+            uint tag;
+
+            while ((tag = input.ReadTag()) != 0)
+            {
+                if (WireFormat.GetTagFieldNumber(tag) == fieldNumber)
+                {
+                    return true;
+                }
+
+                input.SkipLastField();
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/SerializationHelperTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/SerializationHelperTest.cs
@@ -8,6 +8,7 @@ using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry.Serdes;
 using Google.Protobuf;
+using Microsoft.Azure.WebJobs.Host.Bindings;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
@@ -18,6 +19,38 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
     /// </summary>
     public class SerializationHelperTest
     {
+        [Fact]
+        public void GetKeyAndValueTypes_WhenParameterTypeIsParameterBindingData_ShouldUseByteArrayValueType()
+        {
+            // Act
+            var result = SerializationHelper.GetKeyAndValueTypes(
+                valueAvroSchemaFromAttribute: null,
+                keyAvroSchemaFromAttribute: null,
+                parameterType: typeof(ParameterBindingData),
+                keyTypeFromAttribute: typeof(Ignore));
+
+            // Assert
+            Assert.Equal(typeof(byte[]), result.ValueType);
+            Assert.Equal(typeof(Ignore), result.KeyType);
+            Assert.False(result.RequiresKey);
+        }
+
+        [Fact]
+        public void GetKeyAndValueTypes_WhenParameterTypeIsParameterBindingDataArray_ShouldUseByteArrayValueType()
+        {
+            // Act
+            var result = SerializationHelper.GetKeyAndValueTypes(
+                valueAvroSchemaFromAttribute: null,
+                keyAvroSchemaFromAttribute: null,
+                parameterType: typeof(ParameterBindingData[]),
+                keyTypeFromAttribute: typeof(Ignore));
+
+            // Assert
+            Assert.Equal(typeof(byte[]), result.ValueType);
+            Assert.Equal(typeof(Ignore), result.KeyType);
+            Assert.False(result.RequiresKey);
+        }
+
         /// <summary>
         /// Test that when SchemaRegistryUrl is provided and valueType is string (Out-of-proc scenario),
         /// the deserializer should still be created for GenericRecord to properly deserialize Avro messages.


### PR DESCRIPTION
## Release 4.3.2

This PR syncs the `dev` branch content to `master` for release **4.3.2**.

### What this PR does
- Replaces master tree with dev content (tree replacement, not merge)
- Removes dev-only files (samples/, Architecture.md, AGENT-RULES.md, lint-architecture.ps1)
- Updates version in `build/common.props` to `4.3.2`

### After merge
The `release-tag` workflow will automatically:
1. Create tag `4.3.2` on master
2. Publish the draft GitHub Release
3. ADO Code Mirror → Official Build → Release Pipeline will follow

### Changes since last release
- Remove LeaderEpoch from KafkaRecord protobuf transport (#640)
- Fix KafkaRecord deferred binding value type (#638)
- Transfer approval ownership for the Release Pipeline (#633)