### PR TITLE
Bump version to 4.3.2 on dev after release

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>4.3.1$(VersionSuffix)</Version>
+    <Version>4.3.2$(VersionSuffix)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>


### PR DESCRIPTION
Automated version bump after release **4.3.2**.

Updates `build/common.props` from the pre-release version to `4.3.2$(VersionSuffix)`.