### PR TITLE
Upgrade Confluent.Kafka to 2.6.1

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -33,11 +33,11 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-    <PackageReference Include="Confluent.Kafka" Version="2.4.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.4.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.4.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.4.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.6.1" />
     <PackageReference Include="Grpc.Tools" Version="2.60.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/LocalSchemaRegistry.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/LocalSchemaRegistry.cs
@@ -28,6 +28,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             }
         }
 
+        public IEnumerable<KeyValuePair<string, string>> Config => new List<KeyValuePair<string, string>>();
+
+        public void ClearLatestCaches()
+        {
+        }
+
+        public void ClearCaches()
+        {
+        }
+
         public string ConstructKeySubjectName(string topic, string recordType = null) => $"{topic}-key";
 
         public string ConstructValueSubjectName(string topic, string recordType = null) => topic;
@@ -67,12 +77,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return Task.FromResult(schema);
         }
 
+        public Task<Schema> GetSchemaBySubjectAndIdAsync(string subject, int id, string format = null)
+        {
+            return GetSchemaAsync(id, format);
+        }
+
         public Task<int> GetSchemaIdAsync(string subject, string schema)
         {
             throw new System.NotImplementedException();
         }
 
+        public Task<RegisteredSchema> GetRegisteredSchemaAsync(string subject, int version, bool ignoreDeletedSchemas)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public Task<int> GetSchemaIdAsync(string subject, Schema schema)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<RegisteredSchema> GetLatestWithMetadataAsync(string subject, IDictionary<string, string> metadata, bool ignoreDeletedSchemas)
         {
             throw new System.NotImplementedException();
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/SerializationHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/SerializationHelper.cs
@@ -143,6 +143,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return new AvroDeserializer<TKey>(schemaRegistry).AsSyncOverAsync();
         }
 
+        private static ISerializer<T> CreateAvroSerializer<T>(ISchemaRegistryClient schemaRegistry)
+        {
+            return new AvroSerializer<T>(schemaRegistry, new AvroSerializerConfig()).AsSyncOverAsync();
+        }
+
+        private static object CreateAvroSerializer(Type recordType, ISchemaRegistryClient schemaRegistry)
+        {
+            var methodInfo = typeof(SerializationHelper).GetMethod(nameof(CreateAvroSerializer), BindingFlags.Static | BindingFlags.NonPublic, null, new[] { typeof(ISchemaRegistryClient) }, null);
+            var genericMethod = methodInfo.MakeGenericMethod(recordType);
+            return genericMethod.Invoke(null, new object[] { schemaRegistry });
+        }
+
         internal static (object, object) ResolveSerializers(Type valueType, Type keyType, string specifiedValueAvroSchema, string specifiedKeyAvroSchema, string schemaRegistryUrl, string schemaRegistryUsername, string schemaRegistryPassword, string topic)
         {
             object keySerializer = null;
@@ -182,22 +194,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             // check for avro serialization
             if (specifiedValueAvroSchema != null || specifiedKeyAvroSchema != null)
             {
-                object serializer = null;
-
                 // create serializers for avro - generic or specific records
                 if (isValueGenericRecord || isValueSpecificRecord)
                 {
                     // create schema registry client only for value schema
                     var valueSchemaRegistry = CreateSchemaRegistry(specifiedValueAvroSchema, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword);
-                    serializer = Activator.CreateInstance(typeof(AvroSerializer<>).MakeGenericType(valueType), valueSchemaRegistry, null /* config */);
-                    valueSerializer = typeof(SyncOverAsyncSerializerExtensionMethods).GetMethod("AsSyncOverAsync").MakeGenericMethod(valueType).Invoke(null, new object[] { serializer });
+                    valueSerializer = CreateAvroSerializer(valueType, valueSchemaRegistry);
                 }
                 if (isKeyGenericRecord || isKeySpecificRecord)
                 {
                     // create schema registry client only for key schema
                     var keySchemaRegistry = CreateSchemaRegistry(specifiedKeyAvroSchema, schemaRegistryUrl, schemaRegistryUsername, schemaRegistryPassword);
-                    serializer = Activator.CreateInstance(typeof(AvroSerializer<>).MakeGenericType(keyType), keySchemaRegistry, null /* config */);
-                    keySerializer = typeof(SyncOverAsyncSerializerExtensionMethods).GetMethod("AsSyncOverAsync").MakeGenericMethod(keyType).Invoke(null, new object[] { serializer });
+                    keySerializer = CreateAvroSerializer(keyType, keySchemaRegistry);
                 }
             }
 
@@ -213,14 +221,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
             if (typeof(GenericRecord).IsAssignableFrom(valueType) || typeof(ISpecificRecord).IsAssignableFrom(valueType))
             {
-                var serializer = Activator.CreateInstance(typeof(AvroSerializer<>).MakeGenericType(valueType), schemaRegistry, null /* config */);
-                valueSerializer = typeof(SyncOverAsyncSerializerExtensionMethods).GetMethod("AsSyncOverAsync").MakeGenericMethod(valueType).Invoke(null, new object[] { serializer });
+                valueSerializer = CreateAvroSerializer(valueType, schemaRegistry);
             }
 
             if (typeof(GenericRecord).IsAssignableFrom(keyType) || typeof(ISpecificRecord).IsAssignableFrom(keyType))
             {
-                var serializer = Activator.CreateInstance(typeof(AvroSerializer<>).MakeGenericType(keyType), schemaRegistry, null /* config */);
-                keySerializer = typeof(SyncOverAsyncSerializerExtensionMethods).GetMethod("AsSyncOverAsync").MakeGenericMethod(keyType).Invoke(null, new object[] { serializer });
+                keySerializer = CreateAvroSerializer(keyType, schemaRegistry);
             }
 
             return (valueSerializer, keySerializer);

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -30,11 +30,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Confluent.Kafka" Version="2.4.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.4.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.4.0" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.4.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
+    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.6.1" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.0" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
@@ -30,7 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
+    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Upgrade `Confluent.Kafka` and matching Schema Registry packages from 2.4.0 to 2.6.1 to pick up the librdkafka SCRAM nonce compatibility fix for Kafka 4.0.
- Align dependent `System.Diagnostics.DiagnosticSource` and `Google.Protobuf` references required by the newer dependency graph.
- Update local Schema Registry compatibility and create Avro serializers with an explicit `AvroSerializerConfig` for Confluent Serdes 2.6.1.

## Validation
- `dotnet build .\src\Microsoft.Azure.WebJobs.Extensions.Kafka\Microsoft.Azure.WebJobs.Extensions.Kafka.csproj --no-restore`
- `dotnet test .\test\Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests\Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj --no-restore` (227/227 passed)
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\lint-architecture.ps1` (0 errors, 0 warnings)
- Targeted E2E Avro/Schema Registry failures after serializer fix: 7/7 passed
- Full Docker E2E suite: 37/37 passed
- Follow-up targeted retry for `SingleItem_With_Schema_Registry`: 1/1 passed after explicit Kafka/Schema Registry readiness checks

Fixes #634