### PR TITLE
Cherry-pick es-metadata.yml to master for internal mirror

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: e8fdf03b-44f7-48d3-8653-a744c922a342
+    routing:
+      defaultAreaPath:
+        org: azfunc
+        path: internal\Azure Functions


### PR DESCRIPTION
## Summary
Cherry-picks Azure/azure-functions-kafka-extension@c0d47c48ceaba05ab2720c7f211734253fd3c4d3 to `master` for internal audit / InventoryAsCode mirror coverage.

## CI / release impact review
- Adds only `es-metadata.yml` (schema 1.0.0); no runtime, package, or version changes.
- GitHub Actions release workflows are manual (`Release Prep`) or require a merged PR labeled `release` (`Release Tag`). This PR is intentionally not labeled `release`, so it should not create tags or publish a GitHub Release.
- ADO code mirror is configured to trigger on `master` and `4.*` tags; merging to `master` is expected to update the internal mirror.
- Official build may run on `master`, but release publishing remains manual through the release pipeline (`trigger: none`).

## Validation
- Inspected `.github/workflows/release-prep.yml`, `.github/workflows/release-tag.yml`, `eng/ci/code-mirror.yml`, `eng/ci/official-build.yml`, `eng/cd/official-release.yml`, and `azure-pipelines.yaml`.
- No code changes; build/tests not run.
