### PR TITLE
Migrate Docker Hub images to ACR cache

### DIFF
--- a/samples/WalletProcessing_KafkademoSample/src/main/resources/docker-compose.yaml
+++ b/samples/WalletProcessing_KafkademoSample/src/main/resources/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -13,7 +13,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -23,7 +23,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:

--- a/samples/WalletProcessing_KafkademoSample/src/main/resources/docker-compose.yaml
+++ b/samples/WalletProcessing_KafkademoSample/src/main/resources/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   schema-registry:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -13,7 +13,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   zookeeper:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -23,7 +23,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:

--- a/samples/java/confluent/Dockerfile
+++ b/samples/java/confluent/Dockerfile
@@ -3,7 +3,7 @@
 ARG BASE_IMAGE=mcr.microsoft.com/azure-functions/base:2.0-alpine
 FROM ${BASE_IMAGE} as runtime-image
 
-FROM openjdk:8u102-jdk as jdk
+FROM funcacrcache.azurecr.io/cache/library/openjdk:8u102-jdk as jdk
 RUN mkdir -p /usr/lib/jvm/java-1.8-openjdk && \
     cp -a "${JAVA_HOME}/." /usr/lib/jvm/java-1.8-openjdk
 

--- a/samples/java/confluent/Dockerfile
+++ b/samples/java/confluent/Dockerfile
@@ -3,8 +3,9 @@
 ARG BASE_IMAGE=mcr.microsoft.com/azure-functions/base:2.0-alpine
 FROM ${BASE_IMAGE} as runtime-image
 
-FROM openjdk:8-jdk-alpine as jdk
-RUN mkdir -p /usr/lib/jvm/java-1.8-openjdk
+FROM openjdk:8u102-jdk as jdk
+RUN mkdir -p /usr/lib/jvm/java-1.8-openjdk && \
+    cp -a "${JAVA_HOME}/." /usr/lib/jvm/java-1.8-openjdk
 
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2-alpine
 

--- a/samples/java/eventhub/Dockerfile
+++ b/samples/java/eventhub/Dockerfile
@@ -3,7 +3,7 @@
 ARG BASE_IMAGE=mcr.microsoft.com/azure-functions/base:2.0-alpine
 FROM ${BASE_IMAGE} as runtime-image
 
-FROM openjdk:8u102-jdk as jdk
+FROM funcacrcache.azurecr.io/cache/library/openjdk:8u102-jdk as jdk
 RUN mkdir -p /usr/lib/jvm/java-1.8-openjdk && \
     cp -a "${JAVA_HOME}/." /usr/lib/jvm/java-1.8-openjdk
 

--- a/samples/java/eventhub/Dockerfile
+++ b/samples/java/eventhub/Dockerfile
@@ -3,8 +3,9 @@
 ARG BASE_IMAGE=mcr.microsoft.com/azure-functions/base:2.0-alpine
 FROM ${BASE_IMAGE} as runtime-image
 
-FROM openjdk:8-jdk-alpine as jdk
-RUN mkdir -p /usr/lib/jvm/java-1.8-openjdk
+FROM openjdk:8u102-jdk as jdk
+RUN mkdir -p /usr/lib/jvm/java-1.8-openjdk && \
+    cp -a "${JAVA_HOME}/." /usr/lib/jvm/java-1.8-openjdk
 
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:2.2-alpine
 

--- a/samples/java/local/.devcontainer/docker-compose.yml
+++ b/samples/java/local/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     command: sleep infinity
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -24,7 +24,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -46,7 +46,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -59,7 +59,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
+    image: funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -94,7 +94,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
     hostname: control-center
     container_name: control-center
     depends_on:

--- a/samples/java/local/.devcontainer/docker-compose.yml
+++ b/samples/java/local/.devcontainer/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       PORT: 9021
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker

--- a/samples/javascript-v4/.devcontainer/docker-compose.yml
+++ b/samples/javascript-v4/.devcontainer/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: sleep infinity
 
   zookeeper:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -25,7 +25,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -47,7 +47,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -60,7 +60,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
+    image: funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -95,7 +95,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -117,7 +117,7 @@ services:
       PORT: 9021
 
   rest-proxy:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker

--- a/samples/javascript-v4/.devcontainer/docker-compose.yml
+++ b/samples/javascript-v4/.devcontainer/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: sleep infinity
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -25,7 +25,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -47,7 +47,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -60,7 +60,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -95,7 +95,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -117,7 +117,7 @@ services:
       PORT: 9021
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker

--- a/samples/javascript/.devcontainer/docker-compose.yml
+++ b/samples/javascript/.devcontainer/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: sleep infinity
 
   zookeeper:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -25,7 +25,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -47,7 +47,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -60,7 +60,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
+    image: funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -95,7 +95,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -117,7 +117,7 @@ services:
       PORT: 9021
 
   rest-proxy:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker

--- a/samples/javascript/.devcontainer/docker-compose.yml
+++ b/samples/javascript/.devcontainer/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: sleep infinity
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -25,7 +25,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -47,7 +47,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -60,7 +60,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -95,7 +95,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -117,7 +117,7 @@ services:
       PORT: 9021
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker

--- a/samples/python/.devcontainer/docker-compose.yml
+++ b/samples/python/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     command: sleep infinity
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -46,7 +46,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -59,7 +59,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
+    image: funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -94,7 +94,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
     hostname: control-center
     container_name: control-center
     depends_on:

--- a/samples/python/.devcontainer/docker-compose.yml
+++ b/samples/python/.devcontainer/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -116,7 +116,7 @@ services:
       PORT: 9021
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker

--- a/samples/typescript-v4/.devcontainer/docker-compose.yml
+++ b/samples/typescript-v4/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     command: sleep infinity
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -24,7 +24,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -46,7 +46,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -59,7 +59,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -94,7 +94,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -116,7 +116,7 @@ services:
       PORT: 9021
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker

--- a/samples/typescript-v4/.devcontainer/docker-compose.yml
+++ b/samples/typescript-v4/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     command: sleep infinity
 
   zookeeper:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -24,7 +24,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -46,7 +46,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -59,7 +59,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
+    image: funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -94,7 +94,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -116,7 +116,7 @@ services:
       PORT: 9021
 
   rest-proxy:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker

--- a/samples/typescript/.devcontainer/docker-compose.yml
+++ b/samples/typescript/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     command: sleep infinity
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -46,7 +46,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -59,7 +59,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   connect:
-    image: cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
+    image: funcacrcache.azurecr.io/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1
     hostname: connect
     container_name: connect
     depends_on:
@@ -94,7 +94,7 @@ services:
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-control-center:5.3.1
     hostname: control-center
     container_name: control-center
     depends_on:

--- a/samples/typescript/.devcontainer/docker-compose.yml
+++ b/samples/typescript/.devcontainer/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -116,7 +116,7 @@ services:
       PORT: 9021
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/kafka-singlenode-compose.yaml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/kafka-singlenode-compose.yaml
@@ -42,7 +42,7 @@ services:
       CLUSTER_ID: Smqq4VQPTXahsrIWU98xeQ
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:latest
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:7.6.0
     depends_on:
       - kafka
     ports:

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/kafka-singlenode-compose.yaml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/kafka-singlenode-compose.yaml
@@ -19,7 +19,7 @@ services:
     # See https://rmoff.net/2018/08/02/kafka-listeners-explained/ for details
     # "`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-'"`-._,-
     #
-    image: confluentinc/cp-kafka:latest
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-kafka:7.6.0
     hostname: kafka
     ports:
       - 9092:9092

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/docker-compose.yml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "7072:7071"
  
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -25,7 +25,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -47,7 +47,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -60,7 +60,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/docker-compose.yml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "7072:7071"
  
   zookeeper:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-zookeeper:5.3.1
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -25,7 +25,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-enterprise-kafka:5.3.1
     hostname: broker
     container_name: broker
     depends_on:
@@ -47,7 +47,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-schema-registry:5.3.1
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -60,7 +60,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   rest-proxy:
-    image: funcacrcache.azurecr.io/cache/funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-kafka-rest:5.3.1
     depends_on:
       - zookeeper
       - broker


### PR DESCRIPTION
Updates Kafka extension Docker Compose files and Java sample Dockerfiles to pull Docker Hub-sourced images through funcacrcache.azurecr.io. This avoids direct Docker Hub access during AzDO builds under network isolation.\n\nFixes the failing public CI run that was still pulling confluentinc/cp-kafka:latest from registry-1.docker.io, and removes duplicated funcacrcache prefixes from earlier image rewrites.