### PR TITLE
fix: restrict librdkafka native library override

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -699,7 +699,8 @@ Confluent.Kafka IProducer → Kafka Broker
 
 1. Detects runtime environment (Azure Functions vs. container vs. local dev)
 2. Searches `runtimes/{rid}/native/` directory in NuGet package layout
-3. Sets `LIBRDKAFKA_LOCATION` environment variable
-4. Confluent.Kafka loads from this location
+3. Ignores `LIBRDKAFKA_LOCATION` in Azure/container execution because hosted app settings must not redirect native library loading
+4. Temporarily allows `LIBRDKAFKA_LOCATION` only as a deprecated local-development workaround
+5. Confluent.Kafka loads from the discovered package path or its normal native asset resolution
 
 This is sensitive to NuGet package layout changes and platform-specific paths.

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
@@ -80,6 +80,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         // Ensure that we return only once the initialization is finished
         static object librdkafkaInitializationLock = new object();
 
+        internal static bool TryGetUserSpecifiedLibrdKafkaLocation(ILogger logger, out string librdKafkaLocation)
+        {
+            librdKafkaLocation = Environment.GetEnvironmentVariable(LibrdKafkaLocationEnvVarName);
+            if (string.IsNullOrWhiteSpace(librdKafkaLocation))
+            {
+                librdKafkaLocation = null;
+                return false;
+            }
+
+            if (IsRunningAsFunctionInAzureOrContainer())
+            {
+                logger.LogWarning("Librdkafka initialization: ignoring {envVarName} because user specified native library paths are not supported when running in Azure or containers", LibrdKafkaLocationEnvVarName);
+                librdKafkaLocation = null;
+                return false;
+            }
+
+            logger.LogWarning("Librdkafka initialization: {envVarName} is deprecated and should only be used for local development", LibrdKafkaLocationEnvVarName);
+            return true;
+        }
+
         /// <summary>
         /// Initializes the librdkafka library from a specific place
         /// This address the problem that running Functions in Azure won't have the current directory where the function code is.
@@ -100,8 +120,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
                 librdkafkaInitialized = true;
 
-                var userSpecifiedLibrdKafkaLocation = Environment.GetEnvironmentVariable(LibrdKafkaLocationEnvVarName);
-                if (!string.IsNullOrWhiteSpace(userSpecifiedLibrdKafkaLocation))
+                if (TryGetUserSpecifiedLibrdKafkaLocation(logger, out var userSpecifiedLibrdKafkaLocation))
                 {
                     logger.LogDebug("Librdkafka initialization: loading librdkafka from user specified location: {librdkafkaPath}", userSpecifiedLibrdKafkaLocation);
                     Confluent.Kafka.Library.Load(userSpecifiedLibrdKafkaLocation);

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         // Ensure that we return only once the initialization is finished
         static object librdkafkaInitializationLock = new object();
 
-        internal static bool TryGetUserSpecifiedLibrdKafkaLocation(ILogger logger, out string librdKafkaLocation)
+        internal static bool TryResolveUserSpecifiedLibrdKafkaLocation(ILogger logger, out string librdKafkaLocation)
         {
             librdKafkaLocation = Environment.GetEnvironmentVariable(LibrdKafkaLocationEnvVarName);
             if (string.IsNullOrWhiteSpace(librdKafkaLocation))
@@ -92,6 +92,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             if (IsRunningAsFunctionInAzureOrContainer())
             {
                 logger.LogWarning("Librdkafka initialization: ignoring {envVarName} because user specified native library paths are not supported when running in Azure or containers", LibrdKafkaLocationEnvVarName);
+                librdKafkaLocation = null;
+                return false;
+            }
+
+            if (!Path.IsPathRooted(librdKafkaLocation))
+            {
+                logger.LogWarning("Librdkafka initialization: ignoring {envVarName} because relative paths are not supported. Use an absolute path.", LibrdKafkaLocationEnvVarName);
+                librdKafkaLocation = null;
+                return false;
+            }
+
+            if (!File.Exists(librdKafkaLocation))
+            {
+                logger.LogWarning("Librdkafka initialization: ignoring {envVarName} because the specified file does not exist: {fileName}", LibrdKafkaLocationEnvVarName, Path.GetFileName(librdKafkaLocation));
                 librdKafkaLocation = null;
                 return false;
             }
@@ -120,9 +134,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
                 librdkafkaInitialized = true;
 
-                if (TryGetUserSpecifiedLibrdKafkaLocation(logger, out var userSpecifiedLibrdKafkaLocation))
+                if (TryResolveUserSpecifiedLibrdKafkaLocation(logger, out var userSpecifiedLibrdKafkaLocation))
                 {
-                    logger.LogDebug("Librdkafka initialization: loading librdkafka from user specified location: {librdkafkaPath}", userSpecifiedLibrdKafkaLocation);
+                    logger.LogDebug("Librdkafka initialization: loading librdkafka from user specified location: {librdkafkaFileName}", Path.GetFileName(userSpecifiedLibrdKafkaLocation));
                     Confluent.Kafka.Library.Load(userSpecifiedLibrdKafkaLocation);
                     return;
                 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
@@ -78,5 +78,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.NotEmpty(actual);
             Assert.Equal(pathInContainer, actual);
         }
+
+        [Fact]
+        public void TryGetUserSpecifiedLibrdKafkaLocation_WhenRunningInAzure_ShouldIgnoreEnvironmentVariable()
+        {
+            const string librdKafkaLocation = @"C:\temp\librdkafka.dll";
+
+            AzureEnvironment.SetRunningInAzureEnvVars();
+            AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.LibrdKafkaLocationEnvVarName, librdKafkaLocation);
+
+            var result = AzureFunctionsFileHelper.TryGetUserSpecifiedLibrdKafkaLocation(NullLogger.Instance, out var actual);
+
+            Assert.False(result);
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGetUserSpecifiedLibrdKafkaLocation_WhenRunningInDevelopment_ShouldReturnEnvironmentVariable()
+        {
+            const string librdKafkaLocation = @"C:\temp\librdkafka.dll";
+
+            AzureEnvironment.SetRunningInAzureEnvVars();
+            AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.AzureFunctionEnvironmentEnvVarName, AzureFunctionsFileHelper.DevelopmentEnvironmentName);
+            AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.LibrdKafkaLocationEnvVarName, librdKafkaLocation);
+
+            var result = AzureFunctionsFileHelper.TryGetUserSpecifiedLibrdKafkaLocation(NullLogger.Instance, out var actual);
+
+            Assert.True(result);
+            Assert.Equal(librdKafkaLocation, actual);
+        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
@@ -80,32 +80,64 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         [Fact]
-        public void TryGetUserSpecifiedLibrdKafkaLocation_WhenRunningInAzure_ShouldIgnoreEnvironmentVariable()
+        public void TryResolveUserSpecifiedLibrdKafkaLocation_WhenRunningInAzure_ShouldIgnoreEnvironmentVariable()
         {
             const string librdKafkaLocation = @"C:\temp\librdkafka.dll";
 
             AzureEnvironment.SetRunningInAzureEnvVars();
             AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.LibrdKafkaLocationEnvVarName, librdKafkaLocation);
 
-            var result = AzureFunctionsFileHelper.TryGetUserSpecifiedLibrdKafkaLocation(NullLogger.Instance, out var actual);
+            var result = AzureFunctionsFileHelper.TryResolveUserSpecifiedLibrdKafkaLocation(NullLogger.Instance, out var actual);
 
             Assert.False(result);
             Assert.Null(actual);
         }
 
         [Fact]
-        public void TryGetUserSpecifiedLibrdKafkaLocation_WhenRunningInDevelopment_ShouldReturnEnvironmentVariable()
+        public void TryResolveUserSpecifiedLibrdKafkaLocation_WhenRunningInDevelopment_WithExistingFile_ShouldReturnLocation()
         {
-            const string librdKafkaLocation = @"C:\temp\librdkafka.dll";
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                AzureEnvironment.SetRunningInAzureEnvVars();
+                AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.AzureFunctionEnvironmentEnvVarName, AzureFunctionsFileHelper.DevelopmentEnvironmentName);
+                AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.LibrdKafkaLocationEnvVarName, tempFile);
 
+                var result = AzureFunctionsFileHelper.TryResolveUserSpecifiedLibrdKafkaLocation(NullLogger.Instance, out var actual);
+
+                Assert.True(result);
+                Assert.Equal(tempFile, actual);
+            }
+            finally
+            {
+                File.Delete(tempFile);
+            }
+        }
+
+        [Fact]
+        public void TryResolveUserSpecifiedLibrdKafkaLocation_WhenPathIsRelative_ShouldReturnFalse()
+        {
             AzureEnvironment.SetRunningInAzureEnvVars();
             AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.AzureFunctionEnvironmentEnvVarName, AzureFunctionsFileHelper.DevelopmentEnvironmentName);
-            AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.LibrdKafkaLocationEnvVarName, librdKafkaLocation);
+            AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.LibrdKafkaLocationEnvVarName, "librdkafka.dll");
 
-            var result = AzureFunctionsFileHelper.TryGetUserSpecifiedLibrdKafkaLocation(NullLogger.Instance, out var actual);
+            var result = AzureFunctionsFileHelper.TryResolveUserSpecifiedLibrdKafkaLocation(NullLogger.Instance, out var actual);
 
-            Assert.True(result);
-            Assert.Equal(librdKafkaLocation, actual);
+            Assert.False(result);
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryResolveUserSpecifiedLibrdKafkaLocation_WhenFileDoesNotExist_ShouldReturnFalse()
+        {
+            AzureEnvironment.SetRunningInAzureEnvVars();
+            AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.AzureFunctionEnvironmentEnvVarName, AzureFunctionsFileHelper.DevelopmentEnvironmentName);
+            AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.LibrdKafkaLocationEnvVarName, @"C:\nonexistent\path\librdkafka.dll");
+
+            var result = AzureFunctionsFileHelper.TryResolveUserSpecifiedLibrdKafkaLocation(NullLogger.Instance, out var actual);
+
+            Assert.False(result);
+            Assert.Null(actual);
         }
     }
 }


### PR DESCRIPTION
## Summary
Restricts `LIBRDKAFKA_LOCATION` so hosted Azure/container executions no longer honor user-specified native library paths. Keeps the local development workaround temporarily, with a deprecation warning.

We found the use case of `LIBRDKAFKA_LOCATION` is core-tools workaround not on Azure.


## Issue
Related: Azure/azure-functions-bucees-planning#1100

## Changes
- Ignore `LIBRDKAFKA_LOCATION` in Azure/container runtime and log a warning.
- Preserve local Development use with a deprecation warning.
- Add unit tests for hosted ignore and Development allow behavior.
- Update architecture documentation for native library loading.

## Behavior Change
Hosted Azure/container apps can no longer use `LIBRDKAFKA_LOCATION` to redirect native library loading. This is intentional security hardening; local Development remains temporarily supported.

## Testing
- [x] Focused unit tests: `dotnet test test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/ --configuration Release --filter FullyQualifiedName~AzureFunctionsFileHelperTest` (8/8 pass)
- [x] Unit tests: `dotnet test test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/ --configuration Release` (229/229 pass)
- [x] Build: `dotnet build src/Microsoft.Azure.WebJobs.Extensions.Kafka/ --configuration Release`
- [x] Architecture lint: `pwsh ./lint-architecture.ps1`
- [x] Whitespace: `git diff --check`
- [ ] E2E tests: not run locally; Windows environment maps `bash` to WSL stub and `/bin/bash` is unavailable. CI should run the Linux/Docker E2E path.

## Self-Review
- [x] No PLAN/SOLUTION/CHECKLIST artifacts included in the commit
- [x] No package dependency changes
- [x] No hardcoded credentials or sensitive data