### PR TITLE
Sanitize PEM certificate strings before SSL configuration

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaScalerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaScalerProvider.cs
@@ -60,13 +60,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 adminConfig.SaslUsername = config.ResolveSecureSetting(nameResolver, kafkaMetaData.Username);
                 adminConfig.SslKeyPassword = config.ResolveSecureSetting(nameResolver, kafkaMetaData.SslKeyPassword);
                 adminConfig.SslCertificatePem = config.ResolveSecureSetting(nameResolver, kafkaMetaData.SslCertificatePEM);
-                adminConfig.SslCaPem = ExtractCertificate(config.ResolveSecureSetting(nameResolver, kafkaMetaData.SslCaPEM));
+                adminConfig.SslCaPem = PemHelper.ExtractCertificate(config.ResolveSecureSetting(nameResolver, kafkaMetaData.SslCaPEM));
                 adminConfig.SslKeyPem = config.ResolveSecureSetting(nameResolver, kafkaMetaData.SslKeyPEM);
 
                 if (!string.IsNullOrEmpty(kafkaMetaData.SslCertificateandKeyPEM))
                 {
-                    adminConfig.SslCertificatePem = ExtractCertificate(kafkaMetaData.SslCertificateandKeyPEM);
-                    adminConfig.SslKeyPem = ExtractPrivateKey(kafkaMetaData.SslCertificateandKeyPEM);
+                    adminConfig.SslCertificatePem = PemHelper.ExtractCertificate(kafkaMetaData.SslCertificateandKeyPEM);
+                    adminConfig.SslKeyPem = PemHelper.ExtractPrivateKey(kafkaMetaData.SslCertificateandKeyPEM);
                 }
 
                 if (kafkaMetaData.AuthenticationMode != BrokerAuthenticationMode.NotSet)
@@ -101,30 +101,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         public ITargetScaler GetTargetScaler()
         {
             return _targetScaler;
-        }
-
-        private string ExtractSection(string pemString, string sectionName)
-        {
-            if (!string.IsNullOrEmpty(pemString))
-            {
-                var regex = new Regex($"-----BEGIN {sectionName}-----(.*?)-----END {sectionName}-----", RegexOptions.Singleline);
-                var match = regex.Match(pemString);
-                if (match.Success)
-                {
-                    return match.Value.Replace("\\n", "\n");
-                }
-            }
-            return null;
-        }
-
-        private string ExtractCertificate(string pemString)
-        {
-             return ExtractSection(pemString, "CERTIFICATE");
-        }
-
-        private string ExtractPrivateKey(string pemString)
-        {
-            return ExtractSection(pemString, "PRIVATE KEY");
         }
 
         internal class KafkaMetaData

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -108,30 +108,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 loggerFactory.CreateLogger(typeof(KafkaProducer<,>)));
         }
 
-        private string ExtractSection(string pemString, string sectionName)
-        {
-            if (!string.IsNullOrEmpty(pemString))
-            {
-                var regex = new Regex($"-----BEGIN {sectionName}-----(.*?)-----END {sectionName}-----", RegexOptions.Singleline);
-                var match = regex.Match(pemString);
-                if (match.Success)
-                {
-                    return match.Value.Replace("\\n", "\n");
-                }
-            }
-            return null;
-        }
-
-        private string ExtractCertificate(string pemString)
-        {
-            return ExtractSection(pemString, "CERTIFICATE");
-        }
-
-        private string ExtractPrivateKey(string pemString)
-        {
-            return ExtractSection(pemString, "PRIVATE KEY");
-        }
-
         public ProducerConfig GetProducerConfig(KafkaProducerEntity entity)
         {
             var sslCertificateLocation = config.ResolveSecureSetting(nameResolver, entity.Attribute.SslCertificateLocation);
@@ -167,9 +143,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 SslKeyPassword = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.SslKeyPassword),
                 SslCertificateLocation = resolvedSslCertificationLocation,
                 SslCaLocation = resolvedSslCaLocation,
-                SslCaPem = ExtractCertificate(this.config.ResolveSecureSetting(nameResolver, entity.Attribute.SslCaPEM)),
-                SslCertificatePem = ExtractCertificate(this.config.ResolveSecureSetting(nameResolver, entity.Attribute.SslCertificatePEM)),
-                SslKeyPem = ExtractPrivateKey(this.config.ResolveSecureSetting(nameResolver, entity.Attribute.SslKeyPEM)),
+                SslCaPem = PemHelper.ExtractCertificate(this.config.ResolveSecureSetting(nameResolver, entity.Attribute.SslCaPEM)),
+                SslCertificatePem = PemHelper.ExtractCertificate(this.config.ResolveSecureSetting(nameResolver, entity.Attribute.SslCertificatePEM)),
+                SslKeyPem = PemHelper.ExtractPrivateKey(this.config.ResolveSecureSetting(nameResolver, entity.Attribute.SslKeyPEM)),
                 Debug = kafkaOptions?.LibkafkaDebug,
                 MetadataMaxAgeMs = kafkaOptions?.MetadataMaxAgeMs,
                 SocketKeepaliveEnable = kafkaOptions?.SocketKeepaliveEnable,
@@ -179,8 +155,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             if (!string.IsNullOrEmpty(entity.Attribute.SslCertificateandKeyPEM))
             {
                 var sslCertificateandKeyPEM = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.SslCertificateandKeyPEM);
-                conf.SslCertificatePem = ExtractCertificate(sslCertificateandKeyPEM);
-                conf.SslKeyPem = ExtractPrivateKey(sslCertificateandKeyPEM);
+                conf.SslCertificatePem = PemHelper.ExtractCertificate(sslCertificateandKeyPEM);
+                conf.SslKeyPem = PemHelper.ExtractPrivateKey(sslCertificateandKeyPEM);
             }
 
             if (entity.Attribute.AuthenticationMode != BrokerAuthenticationMode.NotSet)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/PemHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/PemHelper.cs
@@ -1,0 +1,89 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    /// <summary>
+    /// Utility methods for sanitizing and extracting PEM-encoded certificates and keys.
+    /// </summary>
+    internal static class PemHelper
+    {
+        /// <summary>
+        /// Sanitizes a PEM certificate/key string by converting literal escape sequences
+        /// (e.g. backslash-n from app settings) into actual newlines and normalizing the format.
+        /// </summary>
+        public static string SanitizePem(string pemValue)
+        {
+            if (string.IsNullOrWhiteSpace(pemValue))
+            {
+                return pemValue;
+            }
+
+            // Replace literal escape sequences (two-character strings) with actual characters.
+            // Order matters: replace \r\n first to avoid double-replacement.
+            string cleaned = pemValue
+                .Replace("\\r\\n", "\n")
+                .Replace("\\n", "\n")
+                .Replace("\\r", "\n");
+
+            // Normalize real line endings
+            cleaned = cleaned
+                .Replace("\r\n", "\n")
+                .Replace("\r", "\n");
+
+            // Split, trim each line, remove empty lines, reassemble
+            var lines = cleaned.Split('\n')
+                .Select(l => l.Trim())
+                .Where(l => !string.IsNullOrEmpty(l))
+                .ToList();
+
+            return string.Join("\n", lines);
+        }
+
+        /// <summary>
+        /// Extracts a PEM section (e.g. CERTIFICATE, PRIVATE KEY) from a PEM string,
+        /// sanitizing literal escape sequences before extraction.
+        /// </summary>
+        public static string ExtractSection(string pemString, string sectionName)
+        {
+            if (string.IsNullOrEmpty(pemString))
+            {
+                return null;
+            }
+
+            // Sanitize first so the regex can match properly
+            string sanitized = SanitizePem(pemString);
+
+            var regex = new Regex(
+                $"-----BEGIN {sectionName}-----(.*?)-----END {sectionName}-----",
+                RegexOptions.Singleline);
+
+            var match = regex.Match(sanitized);
+            if (match.Success)
+            {
+                return match.Value;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Extracts a CERTIFICATE PEM block from the given string.
+        /// </summary>
+        public static string ExtractCertificate(string pemString)
+        {
+            return ExtractSection(pemString, "CERTIFICATE");
+        }
+
+        /// <summary>
+        /// Extracts a PRIVATE KEY PEM block from the given string.
+        /// </summary>
+        public static string ExtractPrivateKey(string pemString)
+        {
+            return ExtractSection(pemString, "PRIVATE KEY");
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -112,14 +112,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 consumerConfig.SslKeyPassword = this.config.ResolveSecureSetting(nameResolver, attribute.SslKeyPassword);
                 consumerConfig.SslCertificateLocation = GetValidFilePath(attribute.SslCertificateLocation);
                 consumerConfig.SslCaLocation = GetValidFilePath(attribute.SslCaLocation);
-                consumerConfig.SslCaPEM = ExtractCertificate(this.config.ResolveSecureSetting(nameResolver, attribute.SslCaPEM));
-                consumerConfig.SslCertificatePEM = ExtractCertificate(this.config.ResolveSecureSetting(nameResolver, attribute.SslCertificatePEM));
-                consumerConfig.SslKeyPEM = ExtractPrivateKey(this.config.ResolveSecureSetting(nameResolver, attribute.SslKeyPEM));
+                consumerConfig.SslCaPEM = PemHelper.ExtractCertificate(this.config.ResolveSecureSetting(nameResolver, attribute.SslCaPEM));
+                consumerConfig.SslCertificatePEM = PemHelper.ExtractCertificate(this.config.ResolveSecureSetting(nameResolver, attribute.SslCertificatePEM));
+                consumerConfig.SslKeyPEM = PemHelper.ExtractPrivateKey(this.config.ResolveSecureSetting(nameResolver, attribute.SslKeyPEM));
                 consumerConfig.SslCertificateandKeyPEM = this.config.ResolveSecureSetting(nameResolver, attribute.SslCertificateandKeyPEM);
 
                 if (!string.IsNullOrEmpty(consumerConfig.SslCertificateandKeyPEM)) {
-                    consumerConfig.SslCertificatePEM = ExtractCertificate(consumerConfig.SslCertificateandKeyPEM);
-                    consumerConfig.SslKeyPEM = ExtractPrivateKey(consumerConfig.SslCertificateandKeyPEM);
+                    consumerConfig.SslCertificatePEM = PemHelper.ExtractCertificate(consumerConfig.SslCertificateandKeyPEM);
+                    consumerConfig.SslKeyPEM = PemHelper.ExtractPrivateKey(consumerConfig.SslCertificateandKeyPEM);
                 }
 
                 if (attribute.AuthenticationMode != BrokerAuthenticationMode.NotSet)
@@ -158,30 +158,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 throw new Exception($"{location} is not a valid file location");
             }
             return validPath;
-        }
-
-        private string ExtractSection(string pemString, string sectionName)
-        {
-            if (!string.IsNullOrEmpty(pemString))
-            {
-                var regex = new Regex($"-----BEGIN {sectionName}-----(.*?)-----END {sectionName}-----", RegexOptions.Singleline);
-                var match = regex.Match(pemString);
-                if (match.Success)
-                {
-                    return match.Value.Replace("\\n", "\n");
-                }
-            }
-            return null;
-        }
-
-        private string ExtractCertificate(string pemString)
-        {
-            return ExtractSection(pemString, "CERTIFICATE");
-        }
-
-        private string ExtractPrivateKey(string pemString)
-        {
-            return ExtractSection(pemString, "PRIVATE KEY");
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/PemHelperTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/PemHelperTest.cs
@@ -1,0 +1,252 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    public class PemHelperTest
+    {
+        private const string ValidCert =
+            "-----BEGIN CERTIFICATE-----\n" +
+            "MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ\n" +
+            "RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD\n" +
+            "VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX\n" +
+            "DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y\n" +
+            "-----END CERTIFICATE-----";
+
+        private const string ValidCertSingleLine =
+            "-----BEGIN CERTIFICATE-----" +
+            "MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ" +
+            "RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD" +
+            "VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX" +
+            "DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y" +
+            "-----END CERTIFICATE-----";
+
+        // Simulates what app settings look like: literal \n characters in a single string
+        private const string CertWithLiteralBackslashN =
+            "-----BEGIN CERTIFICATE-----\\n" +
+            "MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ\\n" +
+            "RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD\\n" +
+            "VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX\\n" +
+            "DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y\\n" +
+            "-----END CERTIFICATE-----";
+
+        private const string CertWithLiteralBackslashRN =
+            "-----BEGIN CERTIFICATE-----\\r\\n" +
+            "MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ\\r\\n" +
+            "RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD\\r\\n" +
+            "VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX\\r\\n" +
+            "DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y\\r\\n" +
+            "-----END CERTIFICATE-----";
+
+        private const string CertWithLiteralBackslashR =
+            "-----BEGIN CERTIFICATE-----\\r" +
+            "MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ\\r" +
+            "RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD\\r" +
+            "VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX\\r" +
+            "DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y\\r" +
+            "-----END CERTIFICATE-----";
+
+        private const string ExpectedSanitizedCert =
+            "-----BEGIN CERTIFICATE-----\n" +
+            "MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ\n" +
+            "RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD\n" +
+            "VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX\n" +
+            "DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y\n" +
+            "-----END CERTIFICATE-----";
+
+        #region SanitizePem Tests
+
+        [Fact]
+        public void SanitizePem_NullInput_ReturnsNull()
+        {
+            Assert.Null(PemHelper.SanitizePem(null));
+        }
+
+        [Fact]
+        public void SanitizePem_EmptyInput_ReturnsEmpty()
+        {
+            Assert.Equal("", PemHelper.SanitizePem(""));
+        }
+
+        [Fact]
+        public void SanitizePem_WhitespaceOnly_ReturnsWhitespace()
+        {
+            Assert.Equal("   ", PemHelper.SanitizePem("   "));
+        }
+
+        [Fact]
+        public void SanitizePem_ValidCert_PreservesStructure()
+        {
+            var result = PemHelper.SanitizePem(ValidCert);
+            Assert.Equal(ExpectedSanitizedCert, result);
+        }
+
+        [Fact]
+        public void SanitizePem_LiteralBackslashN_ConvertedToNewlines()
+        {
+            var result = PemHelper.SanitizePem(CertWithLiteralBackslashN);
+            Assert.Equal(ExpectedSanitizedCert, result);
+            Assert.DoesNotContain("\\n", result);
+        }
+
+        [Fact]
+        public void SanitizePem_LiteralBackslashRN_ConvertedToNewlines()
+        {
+            var result = PemHelper.SanitizePem(CertWithLiteralBackslashRN);
+            Assert.Equal(ExpectedSanitizedCert, result);
+            Assert.DoesNotContain("\\r", result);
+            Assert.DoesNotContain("\\n", result);
+        }
+
+        [Fact]
+        public void SanitizePem_LiteralBackslashR_ConvertedToNewlines()
+        {
+            var result = PemHelper.SanitizePem(CertWithLiteralBackslashR);
+            Assert.Equal(ExpectedSanitizedCert, result);
+            Assert.DoesNotContain("\\r", result);
+        }
+
+        [Fact]
+        public void SanitizePem_RealCRLF_NormalizedToLF()
+        {
+            var input = "-----BEGIN CERTIFICATE-----\r\nBODY\r\n-----END CERTIFICATE-----";
+            var result = PemHelper.SanitizePem(input);
+            Assert.Equal("-----BEGIN CERTIFICATE-----\nBODY\n-----END CERTIFICATE-----", result);
+            Assert.DoesNotContain("\r", result);
+        }
+
+        [Fact]
+        public void SanitizePem_TrimsWhitespaceFromLines()
+        {
+            var input = "  -----BEGIN CERTIFICATE-----  \n  BODY  \n  -----END CERTIFICATE-----  ";
+            var result = PemHelper.SanitizePem(input);
+            Assert.Equal("-----BEGIN CERTIFICATE-----\nBODY\n-----END CERTIFICATE-----", result);
+        }
+
+        [Fact]
+        public void SanitizePem_RemovesEmptyLines()
+        {
+            var input = "-----BEGIN CERTIFICATE-----\n\nBODY\n\n-----END CERTIFICATE-----";
+            var result = PemHelper.SanitizePem(input);
+            Assert.Equal("-----BEGIN CERTIFICATE-----\nBODY\n-----END CERTIFICATE-----", result);
+        }
+
+        #endregion
+
+        #region ExtractCertificate Tests
+
+        [Fact]
+        public void ExtractCertificate_NullInput_ReturnsNull()
+        {
+            Assert.Null(PemHelper.ExtractCertificate(null));
+        }
+
+        [Fact]
+        public void ExtractCertificate_EmptyInput_ReturnsNull()
+        {
+            Assert.Null(PemHelper.ExtractCertificate(""));
+        }
+
+        [Fact]
+        public void ExtractCertificate_ValidCert_ReturnsCertBlock()
+        {
+            var result = PemHelper.ExtractCertificate(ValidCert);
+            Assert.NotNull(result);
+            Assert.StartsWith("-----BEGIN CERTIFICATE-----", result);
+            Assert.EndsWith("-----END CERTIFICATE-----", result);
+        }
+
+        [Fact]
+        public void ExtractCertificate_LiteralBackslashN_ReturnsSanitizedCert()
+        {
+            var result = PemHelper.ExtractCertificate(CertWithLiteralBackslashN);
+            Assert.NotNull(result);
+            Assert.DoesNotContain("\\n", result);
+            Assert.StartsWith("-----BEGIN CERTIFICATE-----", result);
+            Assert.EndsWith("-----END CERTIFICATE-----", result);
+        }
+
+        [Fact]
+        public void ExtractCertificate_NoCertBlock_ReturnsNull()
+        {
+            var result = PemHelper.ExtractCertificate("just some random text");
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ExtractCertificate_CertWithExtraText_ExtractsOnlyCertBlock()
+        {
+            var input = "EXTRA TEXT BEFORE\n" + ValidCert + "\nEXTRA TEXT AFTER";
+            var result = PemHelper.ExtractCertificate(input);
+            Assert.NotNull(result);
+            Assert.StartsWith("-----BEGIN CERTIFICATE-----", result);
+            Assert.EndsWith("-----END CERTIFICATE-----", result);
+            Assert.DoesNotContain("EXTRA TEXT", result);
+        }
+
+        #endregion
+
+        #region ExtractPrivateKey Tests
+
+        [Fact]
+        public void ExtractPrivateKey_NullInput_ReturnsNull()
+        {
+            Assert.Null(PemHelper.ExtractPrivateKey(null));
+        }
+
+        [Fact]
+        public void ExtractPrivateKey_ValidKey_ReturnsKeyBlock()
+        {
+            var keyPem = "-----BEGIN PRIVATE KEY-----\nKEYDATA\n-----END PRIVATE KEY-----";
+            var result = PemHelper.ExtractPrivateKey(keyPem);
+            Assert.NotNull(result);
+            Assert.StartsWith("-----BEGIN PRIVATE KEY-----", result);
+            Assert.EndsWith("-----END PRIVATE KEY-----", result);
+        }
+
+        [Fact]
+        public void ExtractPrivateKey_LiteralBackslashN_ReturnsSanitizedKey()
+        {
+            var keyPem = "-----BEGIN PRIVATE KEY-----\\nKEYDATA\\n-----END PRIVATE KEY-----";
+            var result = PemHelper.ExtractPrivateKey(keyPem);
+            Assert.NotNull(result);
+            Assert.DoesNotContain("\\n", result);
+            Assert.StartsWith("-----BEGIN PRIVATE KEY-----", result);
+        }
+
+        [Fact]
+        public void ExtractPrivateKey_NoKeyBlock_ReturnsNull()
+        {
+            var result = PemHelper.ExtractPrivateKey("no key here");
+            Assert.Null(result);
+        }
+
+        #endregion
+
+        #region Combined Cert + Key Extraction
+
+        [Fact]
+        public void ExtractCertificate_FromCombinedPem_ReturnsOnlyCert()
+        {
+            var combined = ValidCert + "\n-----BEGIN PRIVATE KEY-----\nKEYDATA\n-----END PRIVATE KEY-----";
+            var result = PemHelper.ExtractCertificate(combined);
+            Assert.NotNull(result);
+            Assert.StartsWith("-----BEGIN CERTIFICATE-----", result);
+            Assert.DoesNotContain("PRIVATE KEY", result);
+        }
+
+        [Fact]
+        public void ExtractPrivateKey_FromCombinedPem_ReturnsOnlyKey()
+        {
+            var combined = ValidCert + "\n-----BEGIN PRIVATE KEY-----\nKEYDATA\n-----END PRIVATE KEY-----";
+            var result = PemHelper.ExtractPrivateKey(combined);
+            Assert.NotNull(result);
+            Assert.StartsWith("-----BEGIN PRIVATE KEY-----", result);
+            Assert.DoesNotContain("CERTIFICATE", result);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Problem

When a PEM CA certificate (`sslCaPEM`) is passed to the Kafka extension via trigger metadata (resolved from app settings), the certificate string often contains literal escape sequences (`\n`, `\r`, `\r\n`) instead of actual newline characters. The SSL library fails because the PEM cert body contains stray literal text instead of proper newlines.

## Fix

Added a shared `PemHelper` utility class that sanitizes PEM strings before they reach librdkafka:

- Converts literal `\r\n`, `\n`, `\r` escape sequences to real newlines
- Normalizes line endings (CRLF to LF)
- Trims whitespace from each line and removes empty lines
- Preserves valid PEM structure (`BEGIN/END` markers on their own lines)

Replaced the duplicated `ExtractSection`/`ExtractCertificate`/`ExtractPrivateKey` methods across 3 files with calls to the shared `PemHelper`.

## Changes

| File | Change |
|------|--------|
| `PemHelper.cs` (new) | Shared PEM sanitization + extraction utility |
| `KafkaProducerFactory.cs` | Delegate to `PemHelper` |
| `KafkaTriggerAttributeBindingProvider.cs` | Delegate to `PemHelper` |
| `KafkaScalerProvider.cs` | Delegate to `PemHelper` |
| `PemHelperTest.cs` (new) | 22 unit tests |

## Testing

- 22 new unit tests covering: literal `\n`, literal `\r\n`, valid cert passthrough, null/empty input, combined cert+key extraction
- All 249 existing unit tests continue to pass

Fixes: ADO Task 37669466