### PR TITLE
Upgrade Confluent Kafka dependencies to 2.11.1

### DIFF
--- a/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
+++ b/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
@@ -5,9 +5,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
+    <PackageReference Include="Confluent.Kafka" Version="2.11.1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.11.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.11.1" />
   </ItemGroup>
    <ItemGroup>
     <None Update="cacert.pem">

--- a/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
+++ b/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
@@ -6,9 +6,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-	  <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
-	  <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
-	  <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
+      <PackageReference Include="Confluent.Kafka" Version="2.11.1" />
+      <PackageReference Include="Confluent.SchemaRegistry" Version="2.11.1" />
+      <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.11.1" />
 	  <PackageReference Include="Google.Protobuf" Version="3.29.1" />
   </ItemGroup>
    <ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -34,10 +34,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.6.1" />
+    <PackageReference Include="Confluent.Kafka" Version="2.11.1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.11.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.11.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.11.1" />
     <PackageReference Include="Grpc.Tools" Version="2.60.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/LocalSchemaRegistry.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Serialization/LocalSchemaRegistry.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Confluent.SchemaRegistry;
 
@@ -29,6 +30,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         }
 
         public IEnumerable<KeyValuePair<string, string>> Config => new List<KeyValuePair<string, string>>();
+
+        public IAuthenticationHeaderValueProvider AuthHeaderProvider => null;
+
+        public IWebProxy Proxy => null;
 
         public void ClearLatestCaches()
         {
@@ -80,6 +85,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         public Task<Schema> GetSchemaBySubjectAndIdAsync(string subject, int id, string format = null)
         {
             return GetSchemaAsync(id, format);
+        }
+
+        public Task<Schema> GetSchemaByGuidAsync(string guid, string format = null)
+        {
+            return GetSchemaAsync(1, format);
         }
 
         public Task<int> GetSchemaIdAsync(string subject, string schema)
@@ -158,6 +168,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         {
             subjects.Add(subject);
             return Task.FromResult(1);
+        }
+
+        public Task<RegisteredSchema> RegisterSchemaWithResponseAsync(string subject, Schema schema, bool normalize = false)
+        {
+            subjects.Add(subject);
+            return Task.FromResult(new RegisteredSchema(subject, 1, 1, schema.SchemaString, schema.SchemaType, schema.References));
         }
 
         public Task<Compatibility> UpdateCompatibilityAsync(Compatibility compatibility, string subject = null)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -30,10 +30,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.6.1" />
+    <PackageReference Include="Confluent.Kafka" Version="2.11.1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.11.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.11.1" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Protobuf" Version="2.11.1" />
     <PackageReference Include="Google.Protobuf" Version="3.26.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.0" />
   </ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/LocalSchemaRegistryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/LocalSchemaRegistryTest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Confluent.SchemaRegistry;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    public class LocalSchemaRegistryTest
+    {
+        private const string AvroSchema = "{\"type\":\"string\"}";
+
+        [Fact]
+        public void OfflineClient_HasNoAuthenticationOrProxy()
+        {
+            var client = new LocalSchemaRegistry(AvroSchema);
+
+            Assert.Null(client.AuthHeaderProvider);
+            Assert.Null(client.Proxy);
+        }
+
+        [Fact]
+        public async Task GetSchemaByGuidAsync_ReturnsLocalSchema()
+        {
+            var client = new LocalSchemaRegistry(AvroSchema);
+
+            var schema = await client.GetSchemaByGuidAsync("ignored-guid");
+
+            Assert.Equal(AvroSchema, schema.SchemaString);
+            Assert.Equal(SchemaType.Avro, schema.SchemaType);
+        }
+
+        [Fact]
+        public async Task RegisterSchemaWithResponseAsync_ReturnsLocalRegistration()
+        {
+            var client = new LocalSchemaRegistry(AvroSchema);
+            var schema = new Schema(AvroSchema, SchemaType.Avro);
+
+            var registeredSchema = await client.RegisterSchemaWithResponseAsync("topic-value", schema);
+
+            Assert.Equal("topic-value", registeredSchema.Subject);
+            Assert.Equal(1, registeredSchema.Version);
+            Assert.Equal(1, registeredSchema.Id);
+            Assert.Equal(AvroSchema, registeredSchema.SchemaString);
+            Assert.Equal(SchemaType.Avro, registeredSchema.SchemaType);
+            Assert.Contains("topic-value", await client.GetAllSubjectsAsync());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- upgrade `Confluent.Kafka` and the Schema Registry packages from 2.6.1 to 2.11.1
- update `LocalSchemaRegistry` for the `ISchemaRegistryClient` interface added by 2.11.1
- add focused tests for the newly required offline client behavior
- keep the sample and end-to-end test dependencies aligned with the extension

## Related
https://github.com/Azure/azure-functions-kafka-extension/issues/649 is related but partial influence.
https://github.com/Azure/azure-functions-kafka-extension/pull/635 is the fix but it will require 2.11.0+

## Why 2.11.1

Confluent.Kafka 2.11 adds the librdkafka support needed for HTTPS CA customization. Version 2.11.1 is the corresponding maintenance release and avoids taking unrelated changes from newer release lines.

## Validation

- Release build of the extension: passed
- Unit tests: 234 passed
- End-to-end tests against Kafka and Schema Registry: 37 passed
- Architecture lint: passed with 0 errors and 0 warnings
- NuGet vulnerability scan for the extension, including transitive dependencies: no vulnerable packages reported