### PR TITLE
Route dependency restores through CFS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+NuGet.config
+**/.npmrc
+**/.venv
+**/__pycache__
+**/bin
+**/node_modules
+**/obj
+**/package-lock.json
+**/pip.conf
+**/pip.ini
+**/target
+**/uv.lock
+**/*.pyc
+**/local.appsettings.tests.json
+**/local.settings.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.sh text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -37,6 +37,15 @@ pool:
     - ImageOverride -equals MMSUbuntu20.04TLS
 
 steps:
+  - task: NuGetAuthenticate@1
+    displayName: Authenticate NuGet feed
+
+  - task: PipAuthenticate@1
+    displayName: Authenticate Python feed
+    inputs:
+      artifactFeeds: 'public/upstream-public'
+      onlyAddExtraIndex: false
+
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'
     inputs:
@@ -56,17 +65,29 @@ steps:
       packageType: sdk
 
   - task: DotNetCoreCLI@2
+    displayName: Restore projects
+    inputs:
+      command: restore
+      projects: |
+        src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+        test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
+        test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+        test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests.csproj
+      feedsToUse: config
+      nugetConfigPath: '$(Build.SourcesDirectory)/NuGet.config'
+
+  - task: DotNetCoreCLI@2
     displayName: Build project
     inputs:
       command: 'build'
-      arguments: '--configuration Release -p:IsLocalBuild=False'
+      arguments: '--configuration Release --no-restore -p:IsLocalBuild=False'
       projects: src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
 
   - task: DotNetCoreCLI@2
     displayName: Build test projects
     inputs:
       command: 'build'
-      arguments: '--configuration Release -p:IsLocalBuild=False'
+      arguments: '--configuration Release --no-restore -p:IsLocalBuild=False'
       projects: |
         test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
         test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -77,6 +98,7 @@ steps:
     inputs:
       command: test
       projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+      arguments: '--configuration Release --no-build --no-restore'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: Component Detection
@@ -93,6 +115,7 @@ steps:
     inputs:
       command: test
       projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
+      arguments: '--configuration Release --no-build --no-restore'
 
   - task: Bash@3
     displayName: Stop Kafka in single node
@@ -140,12 +163,20 @@ steps:
       targetType: filePath
       filePath: ./script/create_package.sh
 
+  - task: DotNetCoreCLI@2
+    displayName: Rebuild project for release package
+    inputs:
+      command: build
+      arguments: '--configuration Release --no-restore -p:IsLocalBuild=False'
+      projects: src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+
 #  - task: DotNetCoreCLI@2
 #    displayName: Run language e2e tests
 #    condition: and(succeeded(), eq(variables.isMasterTriggered, 'False')) # Skip in master until we fix the connections
 #    inputs:
 #      command: test
 #      projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests
+#      arguments: '--configuration Release --no-build --no-restore'
 #    env:
 #      AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
 #      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
@@ -168,6 +199,7 @@ steps:
       searchPatternPack: src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
       configurationToPack: Release
       includesymbols: true
+      nobuild: true
 
   - task: EsrpCodeSigning@1
     displayName: Sign extension package

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -53,6 +53,9 @@ extends:
                   targetPath: $(Build.ArtifactStagingDirectory)
                   artifactName: drop
             steps:
+              - task: NuGetAuthenticate@1
+                displayName: Authenticate NuGet feed
+
               - task: UseDotNet@2
                 displayName: "Install .NET Core SDK"
                 inputs:
@@ -72,17 +75,29 @@ extends:
                   packageType: sdk
 
               - task: DotNetCoreCLI@2
+                displayName: Restore projects
+                inputs:
+                  command: restore
+                  projects: |
+                    src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+                    test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
+                    test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+                    test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests.csproj
+                  feedsToUse: config
+                  nugetConfigPath: '$(Build.SourcesDirectory)/NuGet.config'
+
+              - task: DotNetCoreCLI@2
                 displayName: Build project
                 inputs:
                   command: "build"
-                  arguments: "--configuration Release -p:IsLocalBuild=False"
+                  arguments: "--configuration Release --no-restore -p:IsLocalBuild=False"
                   projects: src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
 
               - task: DotNetCoreCLI@2
                 displayName: Build test projects
                 inputs:
                   command: "build"
-                  arguments: "--configuration Release -p:IsLocalBuild=False"
+                  arguments: "--configuration Release --no-restore -p:IsLocalBuild=False"
                   projects: |
                     test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
                     test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -101,12 +116,15 @@ extends:
                   cd ../EventHub
                   mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
                 displayName: "Package Java Functions for Codeql"
+                env:
+                  RestoreConfigFile: $(Build.SourcesDirectory)/NuGet.config
 
               - task: DotNetCoreCLI@2
                 displayName: Run unit tests
                 inputs:
                   command: test
                   projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+                  arguments: '--configuration Release --no-build --no-restore'
 
               - template: ci/sign-files.yml@eng
                 parameters:
@@ -123,6 +141,7 @@ extends:
                   searchPatternPack: src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
                   configurationToPack: Release
                   includesymbols: true
+                  nobuild: true
 
               - template: ci/sign-files.yml@eng
                 parameters:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -59,6 +59,9 @@ extends:
             targetPath: $(Build.ArtifactStagingDirectory)
             artifactName: drop
         steps:
+          - task: NuGetAuthenticate@1
+            displayName: Authenticate NuGet feed
+
           - task: UseDotNet@2
             displayName: 'Install .NET Core SDK'
             inputs:
@@ -78,17 +81,29 @@ extends:
               packageType: sdk
 
           - task: DotNetCoreCLI@2
+            displayName: Restore projects
+            inputs:
+              command: restore
+              projects: |
+                src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+                test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
+                test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+                test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests.csproj
+              feedsToUse: config
+              nugetConfigPath: '$(Build.SourcesDirectory)/NuGet.config'
+
+          - task: DotNetCoreCLI@2
             displayName: Build project
             inputs:
               command: 'build'
-              arguments: '--configuration Release -p:IsLocalBuild=False'
+              arguments: '--configuration Release --no-restore -p:IsLocalBuild=False'
               projects: src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
 
           - task: DotNetCoreCLI@2
             displayName: Build test projects
             inputs:
               command: 'build'
-              arguments: '--configuration Release -p:IsLocalBuild=False'
+              arguments: '--configuration Release --no-restore -p:IsLocalBuild=False'
               projects: |
                 test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
                 test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -99,7 +114,7 @@ extends:
             inputs:
               command: test
               projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
-              arguments: '--collect:"XPlat Code Coverage"'
+              arguments: '--configuration Release --no-build --no-restore --collect:"XPlat Code Coverage"'
 
           - task: PublishCodeCoverageResults@1
             displayName: Publish code coverage
@@ -119,6 +134,7 @@ extends:
             inputs:
               command: test
               projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
+              arguments: '--configuration Release --no-build --no-restore'
 
           - task: Bash@3
             displayName: Stop Kafka in single node
@@ -135,3 +151,4 @@ extends:
               searchPatternPack: src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
               configurationToPack: Release
               includesymbols: true
+              nobuild: true

--- a/script/create_package.ps1
+++ b/script/create_package.ps1
@@ -1,8 +1,91 @@
-# Build the package
-dotnet pack -o temp --include-symbols src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj /p:Version=100.100.100-pre
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
-docker build -f .\test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\FunctionApps\java\EventHub\Dockerfile -t azure-functions-kafka-java-eventhub .
-docker build -f .\test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\FunctionApps\python\EventHub\Dockerfile -t azure-functions-kafka-python-eventhub .
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$projectPath = Join-Path $repositoryRoot 'src\Microsoft.Azure.WebJobs.Extensions.Kafka\Microsoft.Azure.WebJobs.Extensions.Kafka.csproj'
+$nugetConfigPath = Join-Path $repositoryRoot 'NuGet.config'
+$workingDirectory = Join-Path $repositoryRoot 'temp'
 
-docker build -f .\test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\FunctionApps\java\Confluent\Dockerfile -t azure-functions-kafka-java-confluent .
-docker build -f .\test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\FunctionApps\python\Confluent\Dockerfile -t azure-functions-kafka-python-confluent .
+if ([string]::IsNullOrWhiteSpace($env:PIP_INDEX_URL)) {
+    throw 'PIP_INDEX_URL must be set to the authenticated CFS Python feed.'
+}
+
+Push-Location $repositoryRoot
+$previousDockerBuildKit = $env:DOCKER_BUILDKIT
+try {
+    if (Test-Path -LiteralPath $workingDirectory) {
+        Remove-Item -LiteralPath $workingDirectory -Recurse -Force
+    }
+
+    $restoreArguments = @(
+        'restore'
+        $projectPath
+        '--configfile'
+        $nugetConfigPath
+    )
+    & dotnet @restoreArguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet restore failed with exit code $LASTEXITCODE."
+    }
+
+    foreach ($packageVersion in @('100.100.100-pre', '4.0.0')) {
+        $packArguments = @(
+            'pack'
+            $projectPath
+            '--output'
+            $workingDirectory
+            '--include-symbols'
+            '--no-restore'
+            "/p:Version=$packageVersion"
+        )
+        & dotnet @packArguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet pack failed for version $packageVersion with exit code $LASTEXITCODE."
+        }
+    }
+
+    $env:DOCKER_BUILDKIT = '1'
+    $builds = @(
+        @{
+            Dockerfile = '.\test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\FunctionApps\java\EventHub\Dockerfile'
+            Image = 'azure-functions-kafka-java-eventhub'
+            Python = $false
+        }
+        @{
+            Dockerfile = '.\test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\FunctionApps\python\EventHub\Dockerfile'
+            Image = 'azure-functions-kafka-python-eventhub'
+            Python = $true
+        }
+        @{
+            Dockerfile = '.\test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\FunctionApps\java\Confluent\Dockerfile'
+            Image = 'azure-functions-kafka-java-confluent'
+            Python = $false
+        }
+        @{
+            Dockerfile = '.\test\Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests\FunctionApps\python\Confluent\Dockerfile'
+            Image = 'azure-functions-kafka-python-confluent'
+            Python = $true
+        }
+    )
+
+    foreach ($build in $builds) {
+        $dockerArguments = @(
+            'build'
+            '--secret'
+            "id=nuget_config,src=$nugetConfigPath"
+        )
+        if ($build.Python) {
+            $dockerArguments += @('--secret', 'id=pip_index_url,env=PIP_INDEX_URL')
+        }
+
+        $dockerArguments += @('-f', $build.Dockerfile, '-t', $build.Image, '.')
+        & docker @dockerArguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "docker build for $($build.Image) failed with exit code $LASTEXITCODE."
+        }
+    }
+}
+finally {
+    $env:DOCKER_BUILDKIT = $previousDockerBuildKit
+    Pop-Location
+}

--- a/script/create_package.sh
+++ b/script/create_package.sh
@@ -1,18 +1,48 @@
 #!/bin/bash
 
-CURRENT_DIR=`pwd`
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $DIR/..
+set -euo pipefail
 
-WORKING_DIR=temp
-if [ -d "$WORKING_DIR" ]; then rm -rf $WORKING_DIR; fi
+CURRENT_DIR=$PWD
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+PROJECT_PATH="$REPOSITORY_ROOT/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj"
+NUGET_CONFIG_PATH="$REPOSITORY_ROOT/NuGet.config"
+WORKING_DIR="$REPOSITORY_ROOT/temp"
 
-dotnet pack -o temp --include-symbols src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj /p:Version=100.100.100-pre
+if [[ -z "${PIP_INDEX_URL:-}" ]]; then
+    echo "PIP_INDEX_URL must be set to the authenticated CFS Python feed." >&2
+    exit 1
+fi
 
-cd $CURRENT_DIR
+cd "$REPOSITORY_ROOT"
+trap 'cd "$CURRENT_DIR"' EXIT
 
-docker build -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/Dockerfile -t azure-functions-kafka-java-eventhub .
-docker build -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/EventHub/Dockerfile -t azure-functions-kafka-python-eventhub .
+if [[ -d "$WORKING_DIR" ]]; then
+    rm -rf -- "$WORKING_DIR"
+fi
 
-docker build -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/Dockerfile -t azure-functions-kafka-java-confluent .
-docker build -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/Confluent/Dockerfile -t azure-functions-kafka-python-confluent .
+restore_args=(
+    restore
+    "$PROJECT_PATH"
+    --configfile "$NUGET_CONFIG_PATH"
+)
+dotnet "${restore_args[@]}"
+
+for package_version in 100.100.100-pre 4.0.0; do
+    pack_args=(
+        pack
+        "$PROJECT_PATH"
+        --output "$WORKING_DIR"
+        --include-symbols
+        --no-restore
+        "/p:Version=$package_version"
+    )
+    dotnet "${pack_args[@]}"
+done
+
+export DOCKER_BUILDKIT=1
+
+docker build --secret "id=nuget_config,src=$NUGET_CONFIG_PATH" -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/Dockerfile -t azure-functions-kafka-java-eventhub .
+docker build --secret "id=nuget_config,src=$NUGET_CONFIG_PATH" --secret id=pip_index_url,env=PIP_INDEX_URL -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/EventHub/Dockerfile -t azure-functions-kafka-python-eventhub .
+
+docker build --secret "id=nuget_config,src=$NUGET_CONFIG_PATH" -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/Dockerfile -t azure-functions-kafka-java-confluent .
+docker build --secret "id=nuget_config,src=$NUGET_CONFIG_PATH" --secret id=pip_index_url,env=PIP_INDEX_URL -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/Confluent/Dockerfile -t azure-functions-kafka-python-confluent .

--- a/script/create_test_nuget_config.sh
+++ b/script/create_test_nuget_config.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <repository-config> <destination-config> <local-package-source>" >&2
+    exit 2
+fi
+
+repository_config=$1
+destination_config=$2
+local_package_source=$3
+
+mkdir -p "$(dirname "$destination_config")"
+cp -- "$repository_config" "$destination_config"
+
+dotnet_args=(
+    nuget add source
+    "$local_package_source"
+    --name local-tests
+    --configfile "$destination_config"
+)
+dotnet "${dotnet_args[@]}"
+
+sed -i '/<packageSource key="upstream-public">/i\
+    <packageSource key="local-tests">\
+      <package pattern="Microsoft.Azure.WebJobs.Extensions.Kafka" />\
+    </packageSource>' "$destination_config"

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/Dockerfile
@@ -11,9 +11,13 @@ COPY . /workspace
 WORKDIR ${WORK_DIR}
 # dotnet 
 
-
-RUN dotnet nuget add source /workspace/temp --name Local && dotnet nuget list source
-RUN mvn clean package
+ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
+RUN --mount=type=secret,id=nuget_config,required=true \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
+    && RestoreConfigFile="${NUGET_CONFIG_PATH}" mvn clean package \
+    && dotnet nuget locals all --clear \
+    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
+    && rm -f "${NUGET_CONFIG_PATH}"
 ENV LD_LIBRARY_PATH=${TARGET_DIR}/bin/runtimes/linux-x64/native
 # WORKDIR ${TARGET_DIR}
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/Dockerfile
@@ -10,9 +10,13 @@ COPY . /workspace
 WORKDIR ${WORK_DIR}
 # dotnet 
 
-
-RUN dotnet nuget add source /workspace/temp --name Local && dotnet nuget list source
-RUN mvn clean package
+ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
+RUN --mount=type=secret,id=nuget_config,required=true \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
+    && RestoreConfigFile="${NUGET_CONFIG_PATH}" mvn clean package \
+    && dotnet nuget locals all --clear \
+    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
+    && rm -f "${NUGET_CONFIG_PATH}"
 ENV LD_LIBRARY_PATH=${TARGET_DIR}/bin/runtimes/linux-x64/native
 # WORKDIR ${TARGET_DIR}
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/Confluent/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/Confluent/Dockerfile
@@ -11,8 +11,15 @@ WORKDIR /workspace/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTes
 ENV LD_LIBRARY_PATH=/workspace/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/Confluent/bin/runtimes/linux-x64/native
 
 RUN python -m venv .venv 
-RUN pip install -r requirements.txt
-RUN dotnet nuget add source /workspace/temp --name local && dotnet nuget list source
-RUN func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre
+RUN --mount=type=secret,id=pip_index_url,required=true \
+    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" \
+    python -m pip install --no-cache-dir --requirement requirements.txt
+ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
+RUN --mount=type=secret,id=nuget_config,required=true \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
+    && RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre \
+    && dotnet nuget locals all --clear \
+    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
+    && rm -f "${NUGET_CONFIG_PATH}"
 
 ENTRYPOINT [ "/bin/bash", "./start.sh" ]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/EventHub/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/EventHub/Dockerfile
@@ -10,8 +10,15 @@ WORKDIR /workspace/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTes
 ENV LD_LIBRARY_PATH=/workspace/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/EventHub/bin/runtimes/linux-x64/native
 
 RUN python -m venv .venv
-RUN pip install -r requirements.txt
-RUN dotnet nuget add source /workspace/temp --name local && dotnet nuget list source
-RUN func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre
+RUN --mount=type=secret,id=pip_index_url,required=true \
+    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" \
+    python -m pip install --no-cache-dir --requirement requirements.txt
+ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
+RUN --mount=type=secret,id=nuget_config,required=true \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
+    && RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre \
+    && dotnet nuget locals all --clear \
+    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
+    && rm -f "${NUGET_CONFIG_PATH}"
 
 ENTRYPOINT [ "/bin/bash", "./start.sh" ]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/java8/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/java8/Dockerfile
@@ -13,8 +13,13 @@ ENV LD_LIBRARY_PATH=${TARGET_DIR}/bin/runtimes/linux-x64/native
 
 RUN mvn clean package
 WORKDIR ${TARGET_DIR}
-RUN dotnet nuget add source /workspace/temp --name Local && dotnet nuget list source
-RUN func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre
+ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
+RUN --mount=type=secret,id=nuget_config,required=true \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
+    && RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre \
+    && dotnet nuget locals all --clear \
+    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
+    && rm -f "${NUGET_CONFIG_PATH}"
 WORKDIR ${WORK_DIR}
 
 ## ENTRYPOINT ["/usr/bin/tail", "-f", "/var/log/dpkg.log"]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/python38/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/python38/Dockerfile
@@ -10,8 +10,15 @@ WORKDIR /workspace/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTes
 ENV LD_LIBRARY_PATH=/workspace/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/python38/bin/runtimes/linux-x64/native
 
 RUN python -m venv .venv 
-RUN pip install -r requirements.txt
-RUN dotnet nuget add source /workspace/temp --name local && dotnet nuget list source
-RUN func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre
+RUN --mount=type=secret,id=pip_index_url,required=true \
+    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" \
+    python -m pip install --no-cache-dir --requirement requirements.txt
+ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
+RUN --mount=type=secret,id=nuget_config,required=true \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
+    && RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre \
+    && dotnet nuget locals all --clear \
+    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
+    && rm -f "${NUGET_CONFIG_PATH}"
 
 ENTRYPOINT [ "/bin/bash", "./start.sh" ]


### PR DESCRIPTION
## Summary

- add a root, clear-first `NuGet.config` that maps every package to the `azfunc/public/upstream-public` CFS feed
- authenticate and perform one explicit config-based restore in each of the three Azure DevOps build definitions, then disable downstream implicit restores
- authenticate the legacy Python Docker path and keep pip and NuGet credentials in BuildKit-only secrets
- harden PowerShell and Bash packaging with explicit restores, structured arguments, restore-free packing, local prerelease/stable test packages, and LF shell enforcement
- keep temporary feed configuration and host build residue out of final test images

Customer npm, Python, and .NET samples/manifests are intentionally unchanged.

## Validation

- restored all four repository projects from an empty NuGet cache; request-host evidence contained only `pkgs.dev.azure.com`
- built all projects and passed 234/234 unit tests after one retry of a pre-existing Azure HOME path race
- exercised restore-free pipeline/script pack paths and audited six generated nupkgs; no feed config, credentials, lockfiles, or `node_modules` leaked
- reproduced the documented anonymous Python cold-file CFS 401, ingested with authenticated maintainer access, then passed a fresh anonymous CFS-only install
- ran the complete four-image packaging helper successfully and audited final image filesystems, environment, and history for credentials, CFS config, host `obj`, customer lockfiles, and package-manager config residue
- built and audited both detached server Dockerfiles; Java completed without dependency failures, and Python restored exclusively through CFS after authenticated ingestion of `Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator` 1.1.7

## Caveat

The pinned legacy Python 3.8 Core Tools image carries .NET SDK 3.1 while the tracked test `extensions.csproj` targets net8.0. Its existing `func extensions install` path therefore logs MSB3971 while returning success. This is unrelated to CFS routing and was not changed or suppressed here.