### PR TITLE
Harden CFS detached restore validation

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -124,12 +124,71 @@ steps:
       filePath: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/stop-kafka-test-environment.sh
       workingDirectory: test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
+  - pwsh: |
+      if ([string]::IsNullOrWhiteSpace($env:SYSTEM_ACCESSTOKEN)) {
+        throw 'System.AccessToken is required to authenticate Docker NuGet restores.'
+      }
+
+      $configPath = Join-Path '$(Agent.TempDirectory)' 'NuGet.CFS.config'
+      Write-Host "##vso[task.setvariable variable=CFS_NUGET_CONFIG]$configPath"
+      $sourceConfigPath = Join-Path '$(Build.SourcesDirectory)' 'NuGet.config'
+      try {
+        Copy-Item -LiteralPath $sourceConfigPath -Destination $configPath -Force
+
+        $arguments = @(
+          'nuget'
+          'update'
+          'source'
+          'upstream-public'
+          '--configfile'
+          $configPath
+          '--username'
+          'AzureDevOps'
+          '--password'
+          $env:SYSTEM_ACCESSTOKEN
+          '--store-password-in-clear-text'
+        )
+        & dotnet @arguments
+        if ($LASTEXITCODE -ne 0) {
+          throw "Unable to configure Docker NuGet authentication (exit code $LASTEXITCODE)."
+        }
+      } catch {
+        Remove-Item -LiteralPath $configPath -Force -ErrorAction SilentlyContinue
+        throw
+      }
+    displayName: Configure Docker NuGet authentication
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+  - task: Bash@3
+    displayName: Package current source as NuGet package and pack it in Docker
+    env:
+      CFS_NUGET_CONFIG: $(CFS_NUGET_CONFIG)
+    inputs:
+      targetType: filePath
+      filePath: ./script/create_package.sh
+
+  - pwsh: |
+      $configPath = Join-Path '$(Agent.TempDirectory)' 'NuGet.CFS.config'
+      if (Test-Path -LiteralPath $configPath) {
+        Remove-Item -LiteralPath $configPath -Force
+      }
+    displayName: Remove Docker NuGet authentication
+    condition: always()
+
+  - task: DotNetCoreCLI@2
+    displayName: Rebuild project for release package
+    inputs:
+      command: build
+      arguments: '--configuration Release --no-restore -p:IsLocalBuild=False'
+      projects: src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+
   - task: EsrpCodeSigning@1
     displayName: Sign extension assembly
     condition: and(succeeded(), eq(variables.isReleaseTriggered, 'True'))
     inputs:
       connectedServiceName: ESRP Service
-      folderPath: src/Microsoft.Azure.WebJobs.Extensions.Kafka/bin/Debug/netstandard2.0/
+      folderPath: src/Microsoft.Azure.WebJobs.Extensions.Kafka/bin/Release/netstandard2.0/
       pattern: Microsoft.Azure.WebJobs.Extensions.Kafka.dll
       signConfigType: inlineSignParams
       inlineOperation: |
@@ -155,20 +214,6 @@ steps:
               "ToolVersion": "1.0"
             }
           ]
-  
-
-  - task: Bash@3
-    displayName: Package current source as NuGet package and pack it in Docker
-    inputs:
-      targetType: filePath
-      filePath: ./script/create_package.sh
-
-  - task: DotNetCoreCLI@2
-    displayName: Rebuild project for release package
-    inputs:
-      command: build
-      arguments: '--configuration Release --no-restore -p:IsLocalBuild=False'
-      projects: src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
 
 #  - task: DotNetCoreCLI@2
 #    displayName: Run language e2e tests

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -129,7 +129,7 @@ extends:
               - template: ci/sign-files.yml@eng
                 parameters:
                   displayName: Sign extension assembly
-                  folderPath: src/Microsoft.Azure.WebJobs.Extensions.Kafka/bin/Debug/netstandard2.0/
+                  folderPath: src/Microsoft.Azure.WebJobs.Extensions.Kafka/bin/Release/netstandard2.0/
                   pattern: Microsoft.Azure.WebJobs.Extensions.Kafka.dll
                   signType: dll
 

--- a/script/create_package.ps1
+++ b/script/create_package.ps1
@@ -9,6 +9,13 @@ $workingDirectory = Join-Path $repositoryRoot 'temp'
 if ([string]::IsNullOrWhiteSpace($env:PIP_INDEX_URL)) {
     throw 'PIP_INDEX_URL must be set to the authenticated CFS Python feed.'
 }
+if ([string]::IsNullOrWhiteSpace($env:CFS_NUGET_CONFIG)) {
+    throw 'CFS_NUGET_CONFIG must point to an authenticated temporary NuGet config.'
+}
+$dockerNugetConfigPath = $env:CFS_NUGET_CONFIG
+if (-not (Test-Path -LiteralPath $dockerNugetConfigPath -PathType Leaf)) {
+    throw "Docker NuGet config does not exist: $dockerNugetConfigPath"
+}
 
 Push-Location $repositoryRoot
 $previousDockerBuildKit = $env:DOCKER_BUILDKIT
@@ -72,7 +79,7 @@ try {
         $dockerArguments = @(
             'build'
             '--secret'
-            "id=nuget_config,src=$nugetConfigPath"
+            "id=nuget_config,src=$dockerNugetConfigPath"
         )
         if ($build.Python) {
             $dockerArguments += @('--secret', 'id=pip_index_url,env=PIP_INDEX_URL')

--- a/script/create_package.sh
+++ b/script/create_package.sh
@@ -12,6 +12,15 @@ if [[ -z "${PIP_INDEX_URL:-}" ]]; then
     echo "PIP_INDEX_URL must be set to the authenticated CFS Python feed." >&2
     exit 1
 fi
+if [[ -z "${CFS_NUGET_CONFIG:-}" ]]; then
+    echo "CFS_NUGET_CONFIG must point to an authenticated temporary NuGet config." >&2
+    exit 1
+fi
+DOCKER_NUGET_CONFIG_PATH=$CFS_NUGET_CONFIG
+if [[ ! -f "$DOCKER_NUGET_CONFIG_PATH" ]]; then
+    echo "Docker NuGet config does not exist: $DOCKER_NUGET_CONFIG_PATH" >&2
+    exit 1
+fi
 
 cd "$REPOSITORY_ROOT"
 trap 'cd "$CURRENT_DIR"' EXIT
@@ -41,8 +50,8 @@ done
 
 export DOCKER_BUILDKIT=1
 
-docker build --secret "id=nuget_config,src=$NUGET_CONFIG_PATH" -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/Dockerfile -t azure-functions-kafka-java-eventhub .
-docker build --secret "id=nuget_config,src=$NUGET_CONFIG_PATH" --secret id=pip_index_url,env=PIP_INDEX_URL -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/EventHub/Dockerfile -t azure-functions-kafka-python-eventhub .
+docker build --secret "id=nuget_config,src=$DOCKER_NUGET_CONFIG_PATH" -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/Dockerfile -t azure-functions-kafka-java-eventhub .
+docker build --secret "id=nuget_config,src=$DOCKER_NUGET_CONFIG_PATH" --secret id=pip_index_url,env=PIP_INDEX_URL -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/EventHub/Dockerfile -t azure-functions-kafka-python-eventhub .
 
-docker build --secret "id=nuget_config,src=$NUGET_CONFIG_PATH" -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/Dockerfile -t azure-functions-kafka-java-confluent .
-docker build --secret "id=nuget_config,src=$NUGET_CONFIG_PATH" --secret id=pip_index_url,env=PIP_INDEX_URL -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/Confluent/Dockerfile -t azure-functions-kafka-python-confluent .
+docker build --secret "id=nuget_config,src=$DOCKER_NUGET_CONFIG_PATH" -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/Dockerfile -t azure-functions-kafka-java-confluent .
+docker build --secret "id=nuget_config,src=$DOCKER_NUGET_CONFIG_PATH" --secret id=pip_index_url,env=PIP_INDEX_URL -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/Confluent/Dockerfile -t azure-functions-kafka-python-confluent .

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/Dockerfile
@@ -13,11 +13,14 @@ WORKDIR ${WORK_DIR}
 
 ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
 RUN --mount=type=secret,id=nuget_config,required=true \
-    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
-    && RestoreConfigFile="${NUGET_CONFIG_PATH}" mvn clean package \
-    && dotnet nuget locals all --clear \
-    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
-    && rm -f "${NUGET_CONFIG_PATH}"
+    set -eu; \
+    trap 'rm -f "${NUGET_CONFIG_PATH}"' EXIT; \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp; \
+    RestoreConfigFile="${NUGET_CONFIG_PATH}" mvn clean package; \
+    test -f "${TARGET_DIR}/bin/Microsoft.Azure.WebJobs.Extensions.Kafka.dll"; \
+    dotnet nuget locals all --clear; \
+    rm -rf /root/.nuget/NuGet /root/.config/NuGet; \
+    find /workspace -type d -name obj -prune -exec rm -rf {} +
 ENV LD_LIBRARY_PATH=${TARGET_DIR}/bin/runtimes/linux-x64/native
 # WORKDIR ${TARGET_DIR}
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/Dockerfile
@@ -12,11 +12,14 @@ WORKDIR ${WORK_DIR}
 
 ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
 RUN --mount=type=secret,id=nuget_config,required=true \
-    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
-    && RestoreConfigFile="${NUGET_CONFIG_PATH}" mvn clean package \
-    && dotnet nuget locals all --clear \
-    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
-    && rm -f "${NUGET_CONFIG_PATH}"
+    set -eu; \
+    trap 'rm -f "${NUGET_CONFIG_PATH}"' EXIT; \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp; \
+    RestoreConfigFile="${NUGET_CONFIG_PATH}" mvn clean package; \
+    test -f "${TARGET_DIR}/bin/Microsoft.Azure.WebJobs.Extensions.Kafka.dll"; \
+    dotnet nuget locals all --clear; \
+    rm -rf /root/.nuget/NuGet /root/.config/NuGet; \
+    find /workspace -type d -name obj -prune -exec rm -rf {} +
 ENV LD_LIBRARY_PATH=${TARGET_DIR}/bin/runtimes/linux-x64/native
 # WORKDIR ${TARGET_DIR}
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/Confluent/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/Confluent/Dockerfile
@@ -12,14 +12,18 @@ ENV LD_LIBRARY_PATH=/workspace/test/Microsoft.Azure.WebJobs.Extensions.Kafka.Lan
 
 RUN python -m venv .venv 
 RUN --mount=type=secret,id=pip_index_url,required=true \
-    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" \
-    python -m pip install --no-cache-dir --requirement requirements.txt
+    set -eu; \
+    trap 'rm -rf /root/.cache/pip' EXIT; \
+    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" python -m pip install --no-cache-dir --requirement requirements.txt
 ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
 RUN --mount=type=secret,id=nuget_config,required=true \
-    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
-    && RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre \
-    && dotnet nuget locals all --clear \
-    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
-    && rm -f "${NUGET_CONFIG_PATH}"
+    set -eu; \
+    trap 'rm -f "${NUGET_CONFIG_PATH}"' EXIT; \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp; \
+    RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre; \
+    test -f bin/Microsoft.Azure.WebJobs.Extensions.Kafka.dll; \
+    dotnet nuget locals all --clear; \
+    rm -rf /root/.nuget/NuGet /root/.config/NuGet; \
+    find /workspace -type d -name obj -prune -exec rm -rf {} +
 
 ENTRYPOINT [ "/bin/bash", "./start.sh" ]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/EventHub/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/python/EventHub/Dockerfile
@@ -11,14 +11,18 @@ ENV LD_LIBRARY_PATH=/workspace/test/Microsoft.Azure.WebJobs.Extensions.Kafka.Lan
 
 RUN python -m venv .venv
 RUN --mount=type=secret,id=pip_index_url,required=true \
-    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" \
-    python -m pip install --no-cache-dir --requirement requirements.txt
+    set -eu; \
+    trap 'rm -rf /root/.cache/pip' EXIT; \
+    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" python -m pip install --no-cache-dir --requirement requirements.txt
 ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
 RUN --mount=type=secret,id=nuget_config,required=true \
-    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
-    && RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre \
-    && dotnet nuget locals all --clear \
-    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
-    && rm -f "${NUGET_CONFIG_PATH}"
+    set -eu; \
+    trap 'rm -f "${NUGET_CONFIG_PATH}"' EXIT; \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp; \
+    RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre; \
+    test -f bin/Microsoft.Azure.WebJobs.Extensions.Kafka.dll; \
+    dotnet nuget locals all --clear; \
+    rm -rf /root/.nuget/NuGet /root/.config/NuGet; \
+    find /workspace -type d -name obj -prune -exec rm -rf {} +
 
 ENTRYPOINT [ "/bin/bash", "./start.sh" ]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/java8/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/java8/Dockerfile
@@ -15,11 +15,14 @@ RUN mvn clean package
 WORKDIR ${TARGET_DIR}
 ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
 RUN --mount=type=secret,id=nuget_config,required=true \
-    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
-    && RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre \
-    && dotnet nuget locals all --clear \
-    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
-    && rm -f "${NUGET_CONFIG_PATH}"
+    set -eu; \
+    trap 'rm -f "${NUGET_CONFIG_PATH}"' EXIT; \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp; \
+    RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre; \
+    test -f bin/Microsoft.Azure.WebJobs.Extensions.Kafka.dll; \
+    dotnet nuget locals all --clear; \
+    rm -rf /root/.nuget/NuGet /root/.config/NuGet; \
+    find /workspace -type d -name obj -prune -exec rm -rf {} +
 WORKDIR ${WORK_DIR}
 
 ## ENTRYPOINT ["/usr/bin/tail", "-f", "/var/log/dpkg.log"]

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/python38/Dockerfile
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/server/python38/Dockerfile
@@ -11,14 +11,18 @@ ENV LD_LIBRARY_PATH=/workspace/test/Microsoft.Azure.WebJobs.Extensions.Kafka.Lan
 
 RUN python -m venv .venv 
 RUN --mount=type=secret,id=pip_index_url,required=true \
-    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" \
-    python -m pip install --no-cache-dir --requirement requirements.txt
+    set -eu; \
+    trap 'rm -rf /root/.cache/pip' EXIT; \
+    PIP_INDEX_URL="$(cat /run/secrets/pip_index_url)" python -m pip install --no-cache-dir --requirement requirements.txt
 ARG NUGET_CONFIG_PATH=/tmp/cfs/NuGet.config
 RUN --mount=type=secret,id=nuget_config,required=true \
-    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp \
-    && RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre \
-    && dotnet nuget locals all --clear \
-    && find /workspace -type d -name obj -prune -exec rm -rf {} + \
-    && rm -f "${NUGET_CONFIG_PATH}"
+    set -eu; \
+    trap 'rm -f "${NUGET_CONFIG_PATH}"' EXIT; \
+    bash /workspace/script/create_test_nuget_config.sh /run/secrets/nuget_config "${NUGET_CONFIG_PATH}" /workspace/temp; \
+    RestoreConfigFile="${NUGET_CONFIG_PATH}" func extensions install --package Microsoft.Azure.WebJobs.Extensions.Kafka --version 100.100.100-pre; \
+    test -f bin/Microsoft.Azure.WebJobs.Extensions.Kafka.dll; \
+    dotnet nuget locals all --clear; \
+    rm -rf /root/.nuget/NuGet /root/.config/NuGet; \
+    find /workspace -type d -name obj -prune -exec rm -rf {} +
 
 ENTRYPOINT [ "/bin/bash", "./start.sh" ]


### PR DESCRIPTION
## Summary

This is a focused hardening follow-up to #657 after cold-cache, detached Docker, signing-order, and final-artifact validation.

- create a temporary authenticated NuGet config in `$(Agent.TempDirectory)`, pass it to Docker only as a BuildKit secret, and remove it both on setup failure and in an unconditional cleanup step
- require `CFS_NUGET_CONFIG` and `PIP_INDEX_URL` for detached packaging so cold GitHub/fork builds fail closed instead of silently attempting anonymous or public fallback restores
- make Core Tools and Maven Docker restores verify the expected Kafka extension assembly, since those tools can report success after an inner MSBuild failure
- remove temporary NuGet configuration, user-level public-feed config, NuGet metadata, pip caches, and `obj` directories in the same image layer, including failure-safe trap cleanup
- rebuild the Release assembly after local test-package creation, sign `bin/Release/netstandard2.0`, and only then create the restore-free package so helper builds cannot invalidate the signed output

Customer samples, templates, requirements files, npm manifests, and lockfiles remain unchanged.

## Validation

- restored all four pipeline projects from fully empty NuGet package/HTTP/plugin caches; request-host evidence contained `pkgs.dev.azure.com` and no `nuget.org`
- built all four projects with `--no-restore`; unit tests passed **234/234**
- ran the complete PowerShell four-image helper with an authenticated NuGet config whose path contains spaces and structured Docker arguments
- built the detached Java server image and audited all five successful images; no feed configs, credentials, NuGet/pip caches, lockfiles, `node_modules`, `obj`, or credential-bearing image metadata/history remained
- audited all four generated local `.nupkg`/symbols packages; no feed endpoint, credential, config, lockfile, `node_modules`, or `obj` content remained
- parsed all changed pipeline YAML and verified rebuild -> Release signing -> `pack --no-build` ordering plus failure and unconditional credential cleanup
- validated Bash and PowerShell fail-closed guards, syntax, structured arguments, and paths containing spaces
- ran the repository-specific .NET PR reviewer after the fixes; no actionable findings remained

## Baseline caveat

The pinned detached Python 3.8/Core Tools image contains only .NET SDK 3.1, while current Core Tools generates a `net8.0` extension project. Its pre-existing MSB3971 remains intentionally unfixed here; the Docker build now fails deterministically on the missing Kafka assembly. A no-cache retry observed only CFS hosts and no direct public registry traffic.

## Repair accounting

Post-PR CFS repair attempt: **1 of 3**. No failed-check reruns have been used.