### PR TITLE
ci: route Maven dependencies through CFS upstream-public feed

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -110,14 +110,25 @@ extends:
                   script: |
                     sudo apt-get install azure-functions-core-tools-4=$(coreToolsVersion)
 
+              # Maven resolves plugins before pom.xml repositories are honored; install the
+              # mirror settings first, then authenticate, so all resolution goes through CFS.
+              - pwsh: |
+                  $m2 = Join-Path $HOME '.m2'
+                  New-Item -ItemType Directory -Path $m2 -Force | Out-Null
+                  Copy-Item '$(Build.SourcesDirectory)/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/settings.xml' (Join-Path $m2 'settings.xml') -Force
+                displayName: "Install Maven settings.xml for CFS"
+
+              - task: MavenAuthenticate@0
+                displayName: "Authenticate Maven to CFS"
+                inputs:
+                  artifactsFeeds: upstream-public
+
               - pwsh: |
                   cd ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent
                   mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
                   cd ../EventHub
                   mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
                 displayName: "Package Java Functions for Codeql"
-                env:
-                  RestoreConfigFile: $(Build.SourcesDirectory)/NuGet.config
 
               - task: DotNetCoreCLI@2
                 displayName: Run unit tests

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/pom.xml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/pom.xml
@@ -17,6 +17,31 @@
         <functionAppName>KafkaConfluentE2E</functionAppName>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/pom.xml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/pom.xml
@@ -17,6 +17,31 @@
         <functionAppName>KafkaEventHubE2E</functionAppName>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/settings.xml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings for Central Feed Service (CFS).
+
+  Each pom.xml overrides the `central` repository so packages are served by the Azure Artifacts
+  feed below. This mirror also covers plugins and extensions resolved before pom repositories are
+  honored. Its id matches the feed name used by MavenAuthenticate@0.
+
+  CI installs this file to ~/.m2/settings.xml before running mvn.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>upstream-public</id>
+      <name>Azure Functions public upstream feed</name>
+      <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
## Summary

Route Maven dependency and plugin resolution through the Azure Artifacts CFS upstream-public feed to eliminate CFSClean/CFSClean2 compliance violations.

### Problem

Official build 20260811.1 (log 54: Stop Network Isolation) reported:
- **CFSClean**: 21 violations → `repo.maven.apache.org` (Maven Central) via Java
- **CFSClean2**: 6 violations → `oss.sonatype.org` (Sonatype) via Java

Root cause: The `Package Java Functions for Codeql` step ran bare `mvn clean package` without a CFS mirror configured. The `RestoreConfigFile` env var only affects .NET MSBuild — it has no effect on Maven.

### Changes

| File | Change |
|------|--------|
| `test/.../java/Confluent/pom.xml` | Add `<repositories>` + `<pluginRepositories>` → CFS upstream-public |
| `test/.../java/EventHub/pom.xml` | Same |
| `test/.../java/settings.xml` | **New** — Maven `<mirror>` redirecting `central` → upstream-public |
| `eng/ci/official-build.yml` | Install settings.xml to `~/.m2`, add `MavenAuthenticate@0`, remove no-op `RestoreConfigFile` env |

### Pattern

Follows the same approach as [azure-functions-java-worker PR #889](https://github.com/Azure/azure-functions-java-worker/pull/889) (commit `ceb218c`).

The `settings.xml` mirror handles plugin resolution that happens _before_ pom.xml repositories are honored. `MavenAuthenticate@0` writes credentials into the same settings file.

### Testing

The next official build should show 0 Maven violations in the CFSClean/CFSClean2 policy reports.