### PR TITLE
[Security] Route Maven dependencies through CFS on master

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -110,14 +110,25 @@ extends:
                   script: |
                     sudo apt-get install azure-functions-core-tools-4=$(coreToolsVersion)
 
+              # Maven resolves plugins before pom.xml repositories are honored; install the
+              # mirror settings first, then authenticate, so all resolution goes through CFS.
+              - pwsh: |
+                  $m2 = Join-Path $HOME '.m2'
+                  New-Item -ItemType Directory -Path $m2 -Force | Out-Null
+                  Copy-Item '$(Build.SourcesDirectory)/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/settings.xml' (Join-Path $m2 'settings.xml') -Force
+                displayName: "Install Maven settings.xml for CFS"
+
+              - task: MavenAuthenticate@0
+                displayName: "Authenticate Maven to CFS"
+                inputs:
+                  artifactsFeeds: upstream-public
+
               - pwsh: |
                   cd ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent
                   mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
                   cd ../EventHub
                   mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
                 displayName: "Package Java Functions for Codeql"
-                env:
-                  RestoreConfigFile: $(Build.SourcesDirectory)/NuGet.config
 
               - task: DotNetCoreCLI@2
                 displayName: Run unit tests

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/pom.xml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/Confluent/pom.xml
@@ -17,6 +17,31 @@
         <functionAppName>KafkaConfluentE2E</functionAppName>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/pom.xml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/EventHub/pom.xml
@@ -17,6 +17,31 @@
         <functionAppName>KafkaEventHubE2E</functionAppName>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/settings.xml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings for Central Feed Service (CFS).
+
+  Each pom.xml overrides the `central` repository so packages are served by the Azure Artifacts
+  feed below. This mirror also covers plugins and extensions resolved before pom repositories are
+  honored. Its id matches the feed name used by MavenAuthenticate@0.
+
+  CI installs this file to ~/.m2/settings.xml before running mvn.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>upstream-public</id>
+      <name>Azure Functions public upstream feed</name>
+      <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
## Purpose

Backport #661 to `master` so Maven dependency and plugin resolution in the official build uses the Azure Artifacts CFS `upstream-public` feed.

This is a direct cherry-pick of commit `13840655abeab0ae9c1bda7fbfa5520ab931df04` from `dev`. It preserves the established `master` tree and does not restore development-only content such as `samples/`.

## Changes

- Add CFS repositories and plugin repositories to the Confluent and EventHub Java POMs
- Add Maven mirror settings for plugin resolution
- Install and authenticate Maven settings before packaging Java Functions in the official build
- Remove the ineffective `RestoreConfigFile` environment variable from the Maven step

## Validation

- Confirmed the backport patch ID matches the original #661 commit
- Parsed the changed Maven POM and settings XML files successfully
- `git diff --check origin/master...HEAD`