### PR TITLE
ci: add npm CFS redirect and fix Sonatype Maven mirror

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+always-auth=true

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -56,6 +56,11 @@ extends:
               - task: NuGetAuthenticate@1
                 displayName: Authenticate NuGet feed
 
+              - task: npmAuthenticate@0
+                displayName: Authenticate npm to CFS
+                inputs:
+                  workingFile: .npmrc
+
               - task: UseDotNet@2
                 displayName: "Install .NET Core SDK"
                 inputs:

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/settings.xml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/settings.xml
@@ -16,7 +16,7 @@
       <id>upstream-public</id>
       <name>Azure Functions public upstream feed</name>
       <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
-      <mirrorOf>central</mirrorOf>
+      <mirrorOf>*</mirrorOf>
     </mirror>
   </mirrors>
 </settings>


### PR DESCRIPTION
## Changes

Fixes remaining CFS violations from build 20260813.1 (after PR #662 resolved Maven Central violations).

### CFSClean2 fix - Sonatype (6 violations eliminated)

Changed `<mirrorOf>central</mirrorOf>` to `<mirrorOf>*</mirrorOf>` in settings.xml so that all Maven repositories (including oss.sonatype.org referenced transitively by azure-functions-maven-plugin) are routed through the CFS upstream-public feed.

### CFSClean fix - npm (50 violations, expected reduction)

Added .npmrc at repo root redirecting npm to the CFS upstream-public feed, and added npmAuthenticate@0 step in official-build.yml to authenticate npm to CFS. This addresses violations from registry.npmjs.org observed via /usr/local/bin/node during the Linux build (SBOM generation step).

## CFS status after PR #662
| Policy | Status | Violations |
|--------|--------|-----------|
| CFSClean | NOT COMPLIANT | 50 (npm / registry.npmjs.org) |
| CFSClean2 | NOT COMPLIANT | 6 (Sonatype / oss.sonatype.org) |
| CFSClean3 | COMPLIANT | 0 |
| Default Deny | COMPLIANT | 0 |

## Expected CFS status after this PR
| Policy | Status |
|--------|--------|
| CFSClean | TBD (may reduce from 50) |
| CFSClean2 | COMPLIANT (0) |

Co-authored-by: Dobby <dobby@microsoft.com>