### PR TITLE
ci: add npm CFS redirect and fix Sonatype Maven mirror (cherry-pick #663)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+always-auth=true

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -56,6 +56,11 @@ extends:
               - task: NuGetAuthenticate@1
                 displayName: Authenticate NuGet feed
 
+              - task: npmAuthenticate@0
+                displayName: Authenticate npm to CFS
+                inputs:
+                  workingFile: .npmrc
+
               - task: UseDotNet@2
                 displayName: "Install .NET Core SDK"
                 inputs:

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/settings.xml
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.LangEndToEndTests/FunctionApps/java/settings.xml
@@ -16,7 +16,7 @@
       <id>upstream-public</id>
       <name>Azure Functions public upstream feed</name>
       <url>https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/maven/v1</url>
-      <mirrorOf>central</mirrorOf>
+      <mirrorOf>*</mirrorOf>
     </mirror>
   </mirrors>
 </settings>


### PR DESCRIPTION
Cherry-pick of PR #663 (merged to dev) to master.

## Changes
- Add `.npmrc` at repo root pointing to CFS upstream-public npm feed
- Add `npmAuthenticate@0` step in `official-build.yml` to authenticate npm to CFS
- Change `<mirrorOf>central</mirrorOf>` to `<mirrorOf>*</mirrorOf>` in `settings.xml` to route all Maven repos (including Sonatype) through CFS

## Context
Build 20260813.1 showed:
- **CFSClean**: 50 violations (npm / registry.npmjs.org) - `.npmrc` + `npmAuthenticate@0` added
- **CFSClean2**: 6 violations (Sonatype / oss.sonatype.org) - `mirrorOf>*` fix

Co-authored-by: Dobby <dobby@microsoft.com>