### PR TITLE
ci: route SBOM npm access through CFS

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -172,3 +172,6 @@ extends:
                   BuildDropPath: $(Build.ArtifactStagingDirectory)
                   PackageName: Microsoft.Azure.WebJobs.Extensions.Kafka
                   Verbosity: Information
+                env:
+                  NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
+                  NPM_CONFIG_REPLACE_REGISTRY_HOST: always


### PR DESCRIPTION
## Summary

Route npm activity started by `ManifestGeneratorTask@0` through the authenticated CFS `upstream-public` feed.

The repository-level `.npmrc` and `npmAuthenticate@0` step do not automatically apply when the SBOM generator starts npm from nested JavaScript and TypeScript sample projects. Those projects contain package lock entries resolved from `registry.npmjs.org`.

This change passes the authenticated root `.npmrc` to child npm processes through `NPM_CONFIG_USERCONFIG` and forces lockfile registry hosts to be replaced with the configured CFS registry through `NPM_CONFIG_REPLACE_REGISTRY_HOST=always`.

## Validation

- Confirmed nested sample projects resolve `npm config get registry` to the CFS feed with these environment variables.
- Confirmed `replace-registry-host` resolves to `always`.
- Confirmed the official pipeline YAML parses successfully.

The latest public pipeline build was already CFSClean-compliant; this targets the explicit SBOM generation task in the official pipeline where the remaining `/usr/local/bin/node` access occurs.