### PR TITLE
Fix Azure environment test isolation

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureEnvironmentTestCollection.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureEnvironmentTestCollection.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class AzureEnvironmentTestCollection
+    {
+        public const string Name = "Azure environment tests";
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
@@ -19,6 +19,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 {
+    [Collection(AzureEnvironmentTestCollection.Name)]
     public class AzureFunctionsFileHelperTest : IDisposable
     {
         public void Dispose()

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaProducerFactoryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaProducerFactoryTest.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 {
+    [Collection(AzureEnvironmentTestCollection.Name)]
     public class KafkaProducerFactoryTest : IDisposable
     {
         private List<FileInfo> createdFiles = new List<FileInfo>();
@@ -29,6 +30,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
         public void Dispose()
         {
+            AzureEnvironment.ClearEnvironmentVariables();
+
             foreach (var fi in this.createdFiles)
             {
                 if (fi.Exists)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
@@ -24,6 +24,7 @@ using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 {
+    [Collection(AzureEnvironmentTestCollection.Name)]
     public class KafkaTriggerAttributeBindingProviderTest : IDisposable
     {
         private List<FileInfo> createdFiles = new List<FileInfo>();
@@ -38,6 +39,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
         public void Dispose()
         {
+            AzureEnvironment.ClearEnvironmentVariables();
+
             foreach (var fi in this.createdFiles)
             {
                 if (fi.Exists)


### PR DESCRIPTION
## Summary
- serialize tests that mutate process-wide Azure environment variables in a dedicated xUnit collection
- disable parallelization for that collection to prevent cross-collection environment races
- restore Azure environment variables from every affected test class disposer

## Root cause
`AzureEnvironment` stores original process environment values in a shared static dictionary. The three test classes mutated those process-wide values while xUnit could run them concurrently, allowing one class to clear another class's Azure state. That caused the producer SSL-location test to intermittently receive `sslCertificate.pfx` instead of the Azure-resolved full path.

## Validation
- `dotnet test test\Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests\ --configuration Release` (234 passed)
- 25 consecutive filtered runs of the three affected classes
- targeted Release build and architecture lint