### PR TITLE
ci: route SBOM npm access through CFS (master)

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -172,3 +172,6 @@ extends:
                   BuildDropPath: $(Build.ArtifactStagingDirectory)
                   PackageName: Microsoft.Azure.WebJobs.Extensions.Kafka
                   Verbosity: Information
+                env:
+                  NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
+                  NPM_CONFIG_REPLACE_REGISTRY_HOST: always


### PR DESCRIPTION
## Summary

Backport #665 to `master` so npm activity started by `ManifestGeneratorTask@0` uses the authenticated CFS `upstream-public` feed.

The repository `.npmrc` does not automatically apply when the SBOM generator starts npm from nested JavaScript and TypeScript sample projects. This passes the authenticated root config through `NPM_CONFIG_USERCONFIG` and forces package-lock registry hosts through the configured CFS registry with `NPM_CONFIG_REPLACE_REGISTRY_HOST=always`.

## Source

- Backport of #665
- Cherry-picked merged commit: `0ade0d755feb2efc9dc4738b8cd880a4de3ca544`

## Validation

- Staged change matched the source commit exactly
- Official pipeline YAML parsed successfully
- `git diff --check` passed