### PR TITLE
[Release] 4.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ Both, trigger and output, can connect to a secure Kafka broker. The following at
 |OAuthBearerClientSecret|sasl.oauthbearer.client.secret|OIDC ClientSecret
 |OAuthBearerScope|sasl.oauthbearer.scope|OIDC Scope
 |OAuthBearerTokenEndpointUrl|sasl.oauthbearer.token.endpoint.url|Token endpoint URL
+|HttpsCaLocation|https.ca.location|File or directory path to CA certificates for verifying the OAuth/OIDC token endpoint certificate. Use `probe` to discover the operating system's default certificate paths. Mutually exclusive with `HttpsCaPem`|
+|HttpsCaPem|https.ca.pem|CA certificate for verifying the OAuth/OIDC token endpoint certificate in PEM format. Mutually exclusive with `HttpsCaLocation`|
 |OAuthBearerExtensions|sasl.oauthbearer.extensions|Comma separated key/value pair required by Confluent Kafka
 
 Username and password should reference a Azure function configuration variable and not be hardcoded.

--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>4.3.2$(VersionSuffix)</Version>
+    <Version>4.3.3</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/AzureFunctionsFileHelper.cs
@@ -233,6 +233,59 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             }
 
             return false;
-        }        
+        }
+
+        internal static bool TryGetValidHttpsCaLocation(string location, out string resolvedLocation)
+        {
+            resolvedLocation = null;
+
+            if (string.IsNullOrWhiteSpace(location))
+            {
+                return false;
+            }
+
+            if (string.Equals(location, "probe", StringComparison.Ordinal))
+            {
+                resolvedLocation = location;
+                return true;
+            }
+
+            if (Directory.Exists(location))
+            {
+                resolvedLocation = location;
+                return true;
+            }
+
+            var basePath = GetFunctionBaseFolder();
+            if (!string.IsNullOrWhiteSpace(basePath))
+            {
+                var relativeLocation = location.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var directoryPathInAzureFunctionFolder = Path.Combine(basePath, relativeLocation);
+                if (Directory.Exists(directoryPathInAzureFunctionFolder))
+                {
+                    resolvedLocation = directoryPathInAzureFunctionFolder;
+                    return true;
+                }
+            }
+
+            return TryGetValidFilePath(location, out resolvedLocation);
+        }
+
+        internal static string GetValidHttpsCaLocation(string location)
+        {
+            if (string.IsNullOrWhiteSpace(location))
+            {
+                return null;
+            }
+
+            if (TryGetValidHttpsCaLocation(location, out var resolvedLocation))
+            {
+                return resolvedLocation;
+            }
+
+            throw new ArgumentException(
+                $"'{ConfigurationExtensions.HttpsCaLocationConfigKey}' must be 'probe' or an existing file or directory: {location}",
+                nameof(location));
+        }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Extensions/ConfigurationExtensions.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Extensions/ConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Confluent.Kafka;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Configuration;
 
@@ -9,6 +10,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 {
     internal static class ConfigurationExtensions
     {
+        internal const string HttpsCaLocationConfigKey = "https.ca.location";
+        internal const string HttpsCaPemConfigKey = "https.ca.pem";
+
         internal static string ResolveSecureSetting(this IConfiguration config, INameResolver nameResolver, string currentValue)
         {
             if (string.IsNullOrWhiteSpace(currentValue))
@@ -19,6 +23,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             var resolved = nameResolver.ResolveWholeString(currentValue);
             var resolvedFromConfig = config.GetConnectionStringOrSetting(resolved);
             return !string.IsNullOrEmpty(resolvedFromConfig) ? resolvedFromConfig : resolved;
+        }
+
+        internal static string NormalizePem(string value)
+        {
+            return string.IsNullOrEmpty(value) ? value : value.Replace("\\n", "\n");
+        }
+
+        internal static void SetOptionalConfigValue(this ClientConfig config, string key, string value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                config.Set(key, value);
+            }
+        }
+
+        internal static void SetHttpsCaCertificate(this ClientConfig config, string location, string pem)
+        {
+            ValidateHttpsCaCertificate(location, pem);
+            config.SetOptionalConfigValue(HttpsCaLocationConfigKey, location);
+            config.SetOptionalConfigValue(HttpsCaPemConfigKey, NormalizePem(pem));
+        }
+
+        internal static void ValidateHttpsCaCertificate(string location, string pem)
+        {
+            if (!string.IsNullOrWhiteSpace(location) && !string.IsNullOrWhiteSpace(pem))
+            {
+                throw new ArgumentException($"'{HttpsCaLocationConfigKey}' and '{HttpsCaPemConfigKey}' are mutually exclusive.");
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListener.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         private KafkaMetricsProvider<TKey, TValue> CreateMetricsProvider()
         {
-            return new KafkaMetricsProvider<TKey, TValue>(this.topicName, new AdminClientConfig(GetConsumerConfiguration()), consumer.Value, this.logger);
+            return new KafkaMetricsProvider<TKey, TValue>(this.topicName, new AdminClientConfig(GetConsumerConfiguration()), consumer.Value, this.logger, ownsConsumer: false);
         }
 
         private KafkaGenericTopicScaler<TKey, TValue> CreateTopicScaler()
@@ -255,6 +255,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 conf.GroupId = consumerGroupToUse;
                 conf.BrokerVersionFallback = EventHubsBrokerVersionFallback;
             }
+
+            ConfigurationExtensions.ValidateHttpsCaCertificate(
+                this.listenerConfiguration.HttpsCaLocation,
+                this.listenerConfiguration.HttpsCaPem);
+            conf.SetHttpsCaCertificate(
+                AzureFunctionsFileHelper.GetValidHttpsCaLocation(this.listenerConfiguration.HttpsCaLocation),
+                this.listenerConfiguration.HttpsCaPem);
 
             return conf;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaMetricsProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaMetricsProvider.cs
@@ -10,19 +10,27 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 {
-    internal class KafkaMetricsProvider<TKey, TValue>
+    internal class KafkaMetricsProvider<TKey, TValue> : IDisposable
     {
         private readonly string topicName;
         private readonly AdminClientConfig adminClientConfig;
         private readonly IConsumer<TKey, TValue> consumer;
         private readonly ILogger logger;
+        private readonly bool ownsConsumer;
+        private bool _disposed;
         protected Lazy<List<TopicPartition>> topicPartitions;
 
         virtual protected internal KafkaTriggerMetrics LastCalculatedMetrics { get; set; }
 
-        internal KafkaMetricsProvider(string topicName, AdminClientConfig adminClientConfig, IConsumer<TKey, TValue> consumer, ILogger logger) : this(topicName, adminClientConfig, logger)
+        internal KafkaMetricsProvider(string topicName, AdminClientConfig adminClientConfig, IConsumer<TKey, TValue> consumer, ILogger logger)
+            : this(topicName, adminClientConfig, consumer, logger, ownsConsumer: true)
+        {
+        }
+
+        internal KafkaMetricsProvider(string topicName, AdminClientConfig adminClientConfig, IConsumer<TKey, TValue> consumer, ILogger logger, bool ownsConsumer) : this(topicName, adminClientConfig, logger)
         {
             this.consumer = consumer;
+            this.ownsConsumer = ownsConsumer;
         }
 
         internal KafkaMetricsProvider(string topicName, AdminClientConfig adminClientConfig, ILogger logger)
@@ -180,6 +188,49 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 diff = Math.Min(watermark.High.Value - committed.Offset.Value, diff);
             }
             return diff;
+        }
+
+        /// <summary>
+        /// Disposes the Kafka consumer and releases native resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes the Kafka consumer and releases native resources.
+        /// </summary>
+        /// <param name="disposing">True if called from Dispose(), false if called from finalizer.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing && ownsConsumer && consumer != null)
+                {
+                    try
+                    {
+                        consumer.Close();
+                    }
+                    catch (Exception ex)
+                    {
+                        logger?.LogWarning(ex, "Error closing Kafka consumer during disposal");
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            consumer.Dispose();
+                        }
+                        catch (Exception ex)
+                        {
+                            logger?.LogWarning(ex, "Error disposing Kafka consumer");
+                        }
+                    }
+                }
+                _disposed = true;
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaScalerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/Scaler/KafkaScalerProvider.cs
@@ -19,13 +19,23 @@ using static Confluent.Kafka.ConfigPropertyNames;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 {
-    internal class KafkaScalerProvider : IScaleMonitorProvider, ITargetScalerProvider
+    internal class KafkaScalerProvider : IScaleMonitorProvider, ITargetScalerProvider, IDisposable
     {
         private readonly KafkaObjectTopicScaler _scaleMonitor;
         private readonly KafkaObjectTargetScaler _targetScaler;
+        private readonly KafkaMetricsProvider<string, string> _metricsProvider;
+        private bool _disposed;
 
 
         public KafkaScalerProvider(IServiceProvider serviceProvider, TriggerMetadata triggerMetadata)
+            : this(serviceProvider, triggerMetadata, config => new ConsumerBuilder<string, string>(config).Build())
+        {
+        }
+
+        internal KafkaScalerProvider(
+            IServiceProvider serviceProvider,
+            TriggerMetadata triggerMetadata,
+            Func<ConsumerConfig, IConsumer<string, string>> consumerFactory)
         {
             var config = serviceProvider.GetService<IConfiguration>();
             var nameResolver = serviceProvider.GetService<INameResolver>();
@@ -39,14 +49,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             ILogger logger = loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Kafka"));
 
             var consumerConfig = GetConsumerConfiguration(kafkaMetadata, config, nameResolver);
-            var consumer = new ConsumerBuilder<string, string>(consumerConfig).Build();
-            var metricsProvider = new KafkaMetricsProvider<string, string>(topicName, new AdminClientConfig(consumerConfig), consumer, logger);
-
-            _scaleMonitor = new KafkaObjectTopicScaler(topicName, consumerGroup, metricsProvider, triggerMetadata.FunctionName, lagThreshold, logger);
-            _targetScaler = new KafkaObjectTargetScaler(topicName, consumerGroup, metricsProvider, triggerMetadata.FunctionName, lagThreshold, logger);
+            var consumer = consumerFactory(consumerConfig);
+            try
+            {
+                _metricsProvider = new KafkaMetricsProvider<string, string>(
+                    topicName,
+                    new AdminClientConfig(consumerConfig),
+                    consumer,
+                    logger,
+                    ownsConsumer: true);
+                _scaleMonitor = new KafkaObjectTopicScaler(topicName, consumerGroup, _metricsProvider, triggerMetadata.FunctionName, lagThreshold, logger);
+                _targetScaler = new KafkaObjectTargetScaler(topicName, consumerGroup, _metricsProvider, triggerMetadata.FunctionName, lagThreshold, logger);
+            }
+            catch
+            {
+                consumer.Dispose();
+                throw;
+            }
         }
 
-        private ConsumerConfig GetConsumerConfiguration(KafkaMetaData kafkaMetaData, IConfiguration config, INameResolver nameResolver)
+        internal static ConsumerConfig GetConsumerConfiguration(KafkaMetaData kafkaMetaData, IConfiguration config, INameResolver nameResolver)
         {
             var adminConfig = new ConsumerConfig() {
                 GroupId = config.ResolveSecureSetting(nameResolver, kafkaMetaData.ConsumerGroup),
@@ -86,6 +108,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                     adminConfig.SaslOauthbearerClientSecret = config.ResolveSecureSetting(nameResolver, kafkaMetaData.OAuthBearerClientSecret);
                     adminConfig.SaslOauthbearerScope = config.ResolveSecureSetting(nameResolver, kafkaMetaData.OAuthBearerScope);
                     adminConfig.SaslOauthbearerTokenEndpointUrl = config.ResolveSecureSetting(nameResolver, kafkaMetaData.OAuthBearerTokenEndpointUrl);
+                    var httpsCaLocation = config.ResolveSecureSetting(nameResolver, kafkaMetaData.HttpsCaLocation);
+                    var httpsCaPem = config.ResolveSecureSetting(nameResolver, kafkaMetaData.HttpsCaPem);
+                    ConfigurationExtensions.ValidateHttpsCaCertificate(httpsCaLocation, httpsCaPem);
+                    adminConfig.SetHttpsCaCertificate(
+                        AzureFunctionsFileHelper.GetValidHttpsCaLocation(httpsCaLocation),
+                        httpsCaPem);
                     adminConfig.SaslOauthbearerExtensions = config.ResolveSecureSetting(nameResolver, kafkaMetaData.OAuthBearerExtensions);
                 }
             }
@@ -103,7 +131,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return _targetScaler;
         }
 
-        private string ExtractSection(string pemString, string sectionName)
+        /// <summary>
+        /// Disposes the metrics provider which in turn disposes the Kafka consumer.
+        /// This releases native threads spawned by librdkafka.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes the metrics provider which in turn disposes the Kafka consumer.
+        /// </summary>
+        /// <param name="disposing">True if called from Dispose(), false if called from finalizer.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _metricsProvider?.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
+        private static string ExtractSection(string pemString, string sectionName)
         {
             if (!string.IsNullOrEmpty(pemString))
             {
@@ -117,12 +171,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return null;
         }
 
-        private string ExtractCertificate(string pemString)
+        private static string ExtractCertificate(string pemString)
         {
              return ExtractSection(pemString, "CERTIFICATE");
         }
 
-        private string ExtractPrivateKey(string pemString)
+        private static string ExtractPrivateKey(string pemString)
         {
             return ExtractSection(pemString, "PRIVATE KEY");
         }
@@ -182,6 +236,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
             [JsonProperty]
             public string OAuthBearerTokenEndpointUrl { get; set; }
+
+            [JsonProperty]
+            public string HttpsCaLocation { get; set; }
+
+            [JsonProperty]
+            public string HttpsCaPem { get; set; }
 
             [JsonProperty]
             public string OAuthBearerExtensions { get; set; }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
@@ -235,6 +235,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         public string OAuthBearerTokenEndpointUrl { get; set; }
 
         /// <summary>
+        /// File or directory path to CA certificates for verifying the OAuth/OIDC token endpoint certificate.
+        /// The special value "probe" uses the operating system's default certificate paths.
+        /// https.ca.location in librdkafka
+        /// </summary>
+        public string HttpsCaLocation { get; set; }
+
+        /// <summary>
+        /// CA certificate for verifying the OAuth/OIDC token endpoint certificate in PEM format.
+        /// https.ca.pem in librdkafka
+        /// </summary>
+        public string HttpsCaPem { get; set; }
+
+        /// <summary>
         /// OAuth Bearer extensions.
         /// Allow additional information to be provided to the broker.
         /// Comma-separated list of key=value pairs. E.g., "supportFeatureX=true,organizationId=sales-emea"

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducerFactory.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             {
                 resolvedSslCaLocation = sslCaLocation;
             }
-            
+
             var sslKeyLocation = config.ResolveSecureSetting(nameResolver, entity.Attribute.SslKeyLocation);
             if (!AzureFunctionsFileHelper.TryGetValidFilePath(sslKeyLocation, out var resolvedSslKeyLocation))
             {
@@ -195,6 +195,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
             if (entity.Attribute.AuthenticationMode == BrokerAuthenticationMode.OAuthBearer)
             {
+                var httpsCaLocation = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.HttpsCaLocation);
+                var httpsCaPem = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.HttpsCaPem);
+                ConfigurationExtensions.ValidateHttpsCaCertificate(httpsCaLocation, httpsCaPem);
+                conf.SetHttpsCaCertificate(AzureFunctionsFileHelper.GetValidHttpsCaLocation(httpsCaLocation), httpsCaPem);
                 conf.SaslOauthbearerMethod = (SaslOauthbearerMethod)entity.Attribute.OAuthBearerMethod;
                 conf.SaslOauthbearerClientId = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerClientId);
                 conf.SaslOauthbearerClientSecret = this.config.ResolveSecureSetting(nameResolver, entity.Attribute.OAuthBearerClientSecret);

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaListenerConfiguration.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaListenerConfiguration.cs
@@ -162,6 +162,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         public string SaslOAuthBearerTokenEndpointUrl { get; set; }
 
         /// <summary>
+        /// File or directory path to CA certificates for verifying the OAuth/OIDC token endpoint certificate.
+        /// The special value "probe" uses the operating system's default certificate paths.
+        /// https.ca.location in librdkafka
+        /// </summary>
+        public string HttpsCaLocation { get; set; }
+
+        /// <summary>
+        /// CA certificate for verifying the OAuth/OIDC token endpoint certificate in PEM format.
+        /// https.ca.pem in librdkafka
+        /// </summary>
+        public string HttpsCaPem { get; set; }
+
+        /// <summary>
         /// OAuth Bearer extensions.
         /// Allow additional information to be provided to the broker.
         /// Comma-separated list of key=value pairs. E.g., "supportFeatureX=true,organizationId=sales-emea"

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttribute.cs
@@ -204,6 +204,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         public string OAuthBearerTokenEndpointUrl { get; set; }
 
         /// <summary>
+        /// File or directory path to CA certificates for verifying the OAuth/OIDC token endpoint certificate.
+        /// The special value "probe" uses the operating system's default certificate paths.
+        /// https.ca.location in librdkafka
+        /// </summary>
+        public string HttpsCaLocation { get; set; }
+
+        /// <summary>
+        /// CA certificate for verifying the OAuth/OIDC token endpoint certificate in PEM format.
+        /// https.ca.pem in librdkafka
+        /// </summary>
+        public string HttpsCaPem { get; set; }
+
+        /// <summary>
         /// OAuth Bearer extensions.
         /// Allow additional information to be provided to the broker.
         /// Comma-separated list of key=value pairs. E.g., "supportFeatureX=true,organizationId=sales-emea"

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerAttributeBindingProvider.cs
@@ -139,6 +139,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                     consumerConfig.SaslOAuthBearerClientSecret = this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerClientSecret);
                     consumerConfig.SaslOAuthBearerScope = this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerScope);
                     consumerConfig.SaslOAuthBearerTokenEndpointUrl = this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerTokenEndpointUrl);
+                    var httpsCaLocation = this.config.ResolveSecureSetting(nameResolver, attribute.HttpsCaLocation);
+                    var httpsCaPem = this.config.ResolveSecureSetting(nameResolver, attribute.HttpsCaPem);
+                    ConfigurationExtensions.ValidateHttpsCaCertificate(httpsCaLocation, httpsCaPem);
+                    consumerConfig.HttpsCaLocation = AzureFunctionsFileHelper.GetValidHttpsCaLocation(httpsCaLocation);
+                    consumerConfig.HttpsCaPem = ConfigurationExtensions.NormalizePem(httpsCaPem);
                     consumerConfig.SaslOAuthBearerExtensions = this.config.ResolveSecureSetting(nameResolver, attribute.OAuthBearerExtensions);
                 }
             }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Constants.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Constants.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         internal const string SchemaRegistryNoKeyTopicName = "schemaRegistryNoKeyTopic";
         internal const string AtLeastOnceTopicName = "atLeastOnceTopic";
         internal const string AtLeastOnceMaxRetriesTopicName = "atLeastOnceMaxRetriesTopic";
-        internal const string ConsumerGroupID = "e2e_tests";
-        internal const string AtLeastOnceConsumerGroupID = "at_least_once_e2e";
-        internal const string AtLeastOnceMaxRetriesConsumerGroupID = "at_least_once_maxretries_e2e";
+        internal const string ConsumerGroupID = "KafkaConsumerGroupID";
+        internal const string AtLeastOnceConsumerGroupID = "KafkaAtLeastOnceConsumerGroupID";
+        internal const string AtLeastOnceMaxRetriesConsumerGroupID = "KafkaAtLeastOnceMaxRetriesConsumerGroupID";
         internal const string SchemaRegistryUrl = "localhost:8081";
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTestFixture.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTestFixture.cs
@@ -69,6 +69,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             }
         }
 
+        public Task CreateTopicsAsync(IEnumerable<TopicSpecification> topicSpecifications)
+        {
+            return CreateTopicsAsync(topicSpecifications, ignoreExistingTopics: true);
+        }
+
         public Task DisposeAsync() => Task.CompletedTask;
 
         /// <summary>
@@ -76,6 +81,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         /// </summary>
         /// <returns>The async.</returns>
         public async Task InitializeAsync()
+        {
+            await CreateTopicsAsync(GetAllTopics(), ignoreExistingTopics: true);
+        }
+
+        private async Task CreateTopicsAsync(IEnumerable<TopicSpecification> topicSpecifications, bool ignoreExistingTopics)
         {
             var adminClientBuilder = new AdminClientBuilder(new AdminClientConfig()
             {
@@ -92,11 +102,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     RequestTimeout = TimeSpan.FromMinutes(2),
                 };
 
-                await adminClient.CreateTopicsAsync(GetAllTopics(), createTopicOptions);
+                await adminClient.CreateTopicsAsync(topicSpecifications, createTopicOptions);
             }
             catch (CreateTopicsException createTopicsException)
             {
-                if (!createTopicsException.Results.All(x => x.Error.Code == ErrorCode.TopicAlreadyExists))
+                if (!ignoreExistingTopics || !createTopicsException.Results.All(x => x.Error.Code == ErrorCode.TopicAlreadyExists))
                 {
                     Console.WriteLine($"Error creation topics: {createTopicsException.ToString()}");
                     throw;

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Confluent.Kafka.Admin;
 using Microsoft.Azure.WebJobs.Extensions.Tests;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Host;
@@ -51,23 +52,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messageMasterPrefix = Guid.NewGuid().ToString();
             var messagePrefixBatch1 = messageMasterPrefix + ":1:";
             var messagePrefixBatch2 = messageMasterPrefix + ":2:";
+            var consumerGroupSettings = await CreateTestSettingsAsync();
 
             var loggerProvider1 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(SingleItem_Single_Partition_Raw_String_Without_Key_Trigger), typeof(KafkaOutputFunctions) }, loggerProvider1))
+            using (var host = await StartHostAsync(new[] { typeof(SingleItem_Single_Partition_Raw_String_Without_Key_Trigger), typeof(KafkaOutputFunctions) }, loggerProvider1, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithOnePartition.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithOnePartition.Name),
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider1.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch1));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider1, messagePrefixBatch1, producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -75,20 +73,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
             var loggerProvider2 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(SingleItem_Single_Partition_Raw_String_Without_Key_Trigger), typeof(KafkaOutputFunctions) }, loggerProvider2))
+            using (var host = await StartHostAsync(new[] { typeof(SingleItem_Single_Partition_Raw_String_Without_Key_Trigger), typeof(KafkaOutputFunctions) }, loggerProvider2, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithOnePartition.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithOnePartition.Name),
                     Enumerable.Range(1 + producedMessagesCount, producedMessagesCount).Select(x => messagePrefixBatch2 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider2.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch2));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider2, messagePrefixBatch2, producedMessagesCount);
             }
 
             // Ensure 2 run does not have any item from previous run
@@ -97,6 +91,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
         private MethodInfo GetStaticMethod(Type type, string methodName) => type.GetMethod(methodName, BindingFlags.Static | BindingFlags.Public);
 
+        private static Task WaitForUserLogMessagesAsync(TestLoggerProvider loggerProvider, string messageText, int expectedCount, int timeout = 180 * 1000)
+        {
+            return loggerProvider.WaitForUserLogMessagesAsync(
+                logMessage => logMessage.FormattedMessage != null && logMessage.FormattedMessage.Contains(messageText),
+                expectedCount,
+                timeout);
+        }
+
         [Fact]
         public async Task SinglePartition_StringValue_ArrayTrigger_Resume_Continue_Where_Stopped()
         {
@@ -104,23 +106,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messageMasterPrefix = Guid.NewGuid().ToString();
             var messagePrefixBatch1 = messageMasterPrefix + ":1:";
             var messagePrefixBatch2 = messageMasterPrefix + ":2:";
+            var consumerGroupSettings = await CreateTestSettingsAsync();
 
             var loggerProvider1 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(MultiItem_KafkaEventData_String_Without_Key_Trigger), typeof(KafkaOutputFunctions) }, loggerProvider1))
+            using (var host = await StartHostAsync(new[] { typeof(MultiItem_KafkaEventData_String_Without_Key_Trigger), typeof(KafkaOutputFunctions) }, loggerProvider1, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithOnePartition.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithOnePartition.Name),
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider1.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch1));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider1, messagePrefixBatch1, producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -130,20 +129,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
             var loggerProvider2 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(MultiItem_KafkaEventData_String_Without_Key_Trigger) }, loggerProvider2))
+            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(MultiItem_KafkaEventData_String_Without_Key_Trigger) }, loggerProvider2, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithOnePartition.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithOnePartition.Name),
                     Enumerable.Range(1 + producedMessagesCount, producedMessagesCount).Select(x => messagePrefixBatch2 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider2.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch2));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider2, messagePrefixBatch2, producedMessagesCount);
 
                 await host.StopAsync();
             }
@@ -159,23 +154,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messageMasterPrefix = Guid.NewGuid().ToString();
             var messagePrefixBatch1 = messageMasterPrefix + ":1:";
             var messagePrefixBatch2 = messageMasterPrefix + ":2:";
+            var consumerGroupSettings = await CreateTestSettingsAsync();
 
             var loggerProvider1 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(MultiItem_RawByteArray_Trigger), typeof(KafkaOutputFunctions) }, loggerProvider1))
+            using (var host = await StartHostAsync(new[] { typeof(MultiItem_RawByteArray_Trigger), typeof(KafkaOutputFunctions) }, loggerProvider1, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithOnePartition.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithOnePartition.Name),
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider1.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch1));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider1, messagePrefixBatch1, producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -185,20 +177,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
             var loggerProvider2 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(MultiItem_RawByteArray_Trigger) }, loggerProvider2))
+            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(MultiItem_RawByteArray_Trigger) }, loggerProvider2, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithOnePartition.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithOnePartition.Name),
                     Enumerable.Range(1 + producedMessagesCount, producedMessagesCount).Select(x => messagePrefixBatch2 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider2.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch2));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider2, messagePrefixBatch2, producedMessagesCount);
 
                 await host.StopAsync();
             }
@@ -214,23 +202,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messageMasterPrefix = Guid.NewGuid().ToString();
             var messagePrefixBatch1 = messageMasterPrefix + ":1:";
             var messagePrefixBatch2 = messageMasterPrefix + ":2:";
+            var consumerGroupSettings = await CreateTestSettingsAsync();
 
             var loggerProvider1 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(SingleItem_SinglePartition_RawByteArray_Trigger), typeof(KafkaOutputFunctions) }, loggerProvider1))
+            using (var host = await StartHostAsync(new[] { typeof(SingleItem_SinglePartition_RawByteArray_Trigger), typeof(KafkaOutputFunctions) }, loggerProvider1, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithOnePartition.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithOnePartition.Name),
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider1.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch1));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider1, messagePrefixBatch1, producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -240,20 +225,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
             var loggerProvider2 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(SingleItem_SinglePartition_RawByteArray_Trigger) }, loggerProvider2))
+            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(SingleItem_SinglePartition_RawByteArray_Trigger) }, loggerProvider2, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithOnePartition.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithOnePartition.Name),
                     Enumerable.Range(1 + producedMessagesCount, producedMessagesCount).Select(x => messagePrefixBatch2 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider2.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch2));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider2, messagePrefixBatch2, producedMessagesCount);
 
                 await host.StopAsync();
             }
@@ -269,23 +250,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messageMasterPrefix = Guid.NewGuid().ToString();
             var messagePrefixBatch1 = messageMasterPrefix + ":1:";
             var messagePrefixBatch2 = messageMasterPrefix + ":2:";
+            var consumerGroupSettings = await CreateTestSettingsAsync();
 
             var loggerProvider1 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(SingleItem_KafkaEventData_String_Without_Key_Trigger) }, loggerProvider1))
+            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(SingleItem_KafkaEventData_String_Without_Key_Trigger) }, loggerProvider1, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithTenPartitions.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithTenPartitions.Name),
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider1.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch1));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider1, messagePrefixBatch1, producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -295,20 +273,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
             var loggerProvider2 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(SingleItem_KafkaEventData_String_Without_Key_Trigger) }, loggerProvider2))
+            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(SingleItem_KafkaEventData_String_Without_Key_Trigger) }, loggerProvider2, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithTenPartitions.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithTenPartitions.Name),
                     Enumerable.Range(1 + producedMessagesCount, producedMessagesCount).Select(x => messagePrefixBatch2 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider2.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch2));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider2, messagePrefixBatch2, producedMessagesCount);
 
                 await host.StopAsync();
             }
@@ -321,26 +295,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         public async Task MultiPartition_StringValue_ArrayTrigger_Resume_Continue_Where_Stopped()
         {
             const int producedMessagesCount = 80;
+            const int waitForAllMessagesTimeoutMs = 180 * 1000;
             var messageMasterPrefix = Guid.NewGuid().ToString();
             var messagePrefixBatch1 = messageMasterPrefix + ":1:";
             var messagePrefixBatch2 = messageMasterPrefix + ":2:";
+            var consumerGroupSettings = await CreateTestSettingsAsync();
 
             var loggerProvider1 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(MultiItem_String_Without_Key_Trigger) }, loggerProvider1))
+            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(MultiItem_String_Without_Key_Trigger) }, loggerProvider1, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithTenPartitions.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithTenPartitions.Name),
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider1.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch1));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider1, messagePrefixBatch1, producedMessagesCount, waitForAllMessagesTimeoutMs);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -350,20 +322,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
             var loggerProvider2 = CreateTestLoggerProvider();
 
-            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(MultiItem_String_Without_Key_Trigger) }, loggerProvider2))
+            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), typeof(MultiItem_String_Without_Key_Trigger) }, loggerProvider2, testSettings: consumerGroupSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithTenPartitions.Name,
+                    ResolveTopicName(consumerGroupSettings, endToEndTestFixture.StringTopicWithTenPartitions.Name),
                     Enumerable.Range(1 + producedMessagesCount, producedMessagesCount).Select(x => messagePrefixBatch2 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider2.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch2));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider2, messagePrefixBatch2, producedMessagesCount, waitForAllMessagesTimeoutMs);
 
                 await host.StopAsync();
             }
@@ -390,34 +358,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
             IHost host1 = null, host2 = null;
             Func<LogMessage, bool> messageFilter = (LogMessage m) => m.FormattedMessage != null && m.FormattedMessage.Contains(messagePrefix);
+            var consumerGroupSettings = await CreateTestSettingsAsync();
 
             try
             {
                 var host1Log = CreateTestLoggerProvider();
                 var host2Log = CreateTestLoggerProvider();
 
-                host1 = await StartHostAsync(typeof(MultiItem_String_Without_Key_Trigger), host1Log);
+                host1 = await StartHostAsync(typeof(MultiItem_String_Without_Key_Trigger), host1Log, testSettings: consumerGroupSettings);
 
                 // wait until host1 receives partitions
-                await TestHelpers.Await(() =>
-                {
-                    var host1HasPartitions = host1Log.GetAllLogMessages().Any(x => x.FormattedMessage != null && x.FormattedMessage.Contains("Assigned partitions"));
-                    return host1HasPartitions;
-                });
+                await host1Log.WaitForLogMessageAsync(
+                    logMessage => logMessage.FormattedMessage != null && logMessage.FormattedMessage.Contains("Assigned partitions"));
 
 
-                host2 = await StartHostAsync(typeof(MultiItem_String_Without_Key_Trigger), host2Log);
+                host2 = await StartHostAsync(typeof(MultiItem_String_Without_Key_Trigger), host2Log, testSettings: consumerGroupSettings);
 
                 // wait until partitions are distributed
-                await TestHelpers.Await(() =>
-                {
-                    var host2HasPartitions = host2Log.GetAllLogMessages().Any(x => x.FormattedMessage != null && x.FormattedMessage.Contains("Assigned partitions"));
-
-                    return host2HasPartitions;
-                });
+                await host2Log.WaitForLogMessageAsync(
+                    logMessage => logMessage.FormattedMessage != null && logMessage.FormattedMessage.Contains("Assigned partitions"));
 
                 await ProduceMessagesToAllPartitionsAsync(
-                    this.endToEndTestFixture.StringTopicWithTenPartitions.Name,
+                    ResolveTopicName(consumerGroupSettings, this.endToEndTestFixture.StringTopicWithTenPartitions.Name),
                     Enumerable.Range(1, producedMessagesCount).Select(x => EndToEndTestExtensions.CreateMessageValue(messagePrefix, x)));
 
                 await TestHelpers.Await(() =>
@@ -556,9 +518,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var loggerProvider = CreateTestLoggerProvider();
 
             var eventList = GetKafkaEventsWithTraceParentHeader(producedMessagesCount);
+            var testSettings = await CreateTestSettingsAsync();
+            var topicName = ResolveTopicName(testSettings, Constants.StringTopicWithOnePartitionName);
             foreach (var kafkaEvent in eventList)
             {
-                kafkaEvent.Topic = Constants.StringTopicWithOnePartitionName;
+                kafkaEvent.Topic = topicName;
             }
             var eventCount = eventList.Count;
 
@@ -566,7 +530,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 serviceRegistrationCallback: s =>
                 {
                     s.AddSingleton(eventList);
-                }))
+                },
+                testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
@@ -574,11 +539,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     typeof(KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>).GetMethod(nameof(KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>.Produce))
                     );
 
-                await TestHelpers.Await(() =>
+                foreach (var kafkaEvent in eventList)
                 {
-                    var foundCount = loggerProvider.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("TraceId:"));
-                    return foundCount == producedMessagesCount;
-                });
+                    var traceparent = Encoding.ASCII.GetString(kafkaEvent.Headers.GetFirst("traceparent"));
+                    var traceId = traceparent.Split('-')[1];
+                    await WaitForUserLogMessagesAsync(loggerProvider, "TraceId:" + traceId, 1);
+                }
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -613,9 +579,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var loggerProvider = CreateTestLoggerProvider();
 
             var eventList = GetKafkaEventsWithoutTraceParentHeader(producedMessagesCount);
+            var testSettings = await CreateTestSettingsAsync();
+            var topicName = ResolveTopicName(testSettings, Constants.StringTopicWithOnePartitionName);
             foreach (var kafkaEvent in eventList)
             {
-                kafkaEvent.Topic = Constants.StringTopicWithOnePartitionName;
+                kafkaEvent.Topic = topicName;
             }
             var eventCount = eventList.Count;
 
@@ -623,7 +591,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 serviceRegistrationCallback: s =>
                 {
                     s.AddSingleton(eventList);
-                }))
+                },
+                testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
@@ -631,11 +600,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     typeof(KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>).GetMethod(nameof(KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>.Produce))
                     );
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("TraceId:"));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider, "TraceId:", producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -671,9 +636,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var loggerProvider = CreateTestLoggerProvider();
 
             var eventList = GetKafkaEventsWithTraceParentHeader(producedMessagesCount);
+            var testSettings = await CreateTestSettingsAsync();
+            var topicName = ResolveTopicName(testSettings, Constants.StringTopicWithOnePartitionName);
             foreach (var kafkaEvent in eventList)
             {
-                kafkaEvent.Topic = Constants.StringTopicWithOnePartitionName;
+                kafkaEvent.Topic = topicName;
             }
             var eventCount = eventList.Count;
 
@@ -681,7 +648,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 serviceRegistrationCallback: s =>
                 {
                     s.AddSingleton(eventList);
-                }))
+                },
+                testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
@@ -689,11 +657,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     typeof(KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>).GetMethod(nameof(KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>.Produce))
                     );
                         
-                await TestHelpers.Await(() =>
+                foreach (var kafkaEvent in eventList)
                 {
-                    var foundCount = loggerProvider.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("TraceId:"));
-                    return foundCount == 1;
-                });
+                    var traceparent = Encoding.ASCII.GetString(kafkaEvent.Headers.GetFirst("traceparent"));
+                    await WaitForUserLogMessagesAsync(loggerProvider, "LinkedActivity: " + traceparent, 1);
+                }
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -727,9 +695,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var loggerProvider = CreateTestLoggerProvider();
 
             var eventList = GetKafkaEventsWithoutTraceParentHeader(producedMessagesCount);
+            var testSettings = await CreateTestSettingsAsync();
+            var topicName = ResolveTopicName(testSettings, Constants.StringTopicWithOnePartitionName);
             foreach (var kafkaEvent in eventList)
             {
-                kafkaEvent.Topic = Constants.StringTopicWithOnePartitionName;
+                kafkaEvent.Topic = topicName;
             }
             var eventCount = eventList.Count;
 
@@ -737,7 +707,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 serviceRegistrationCallback: s =>
                 {
                     s.AddSingleton(eventList);
-                }))
+                },
+                testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
@@ -745,11 +716,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     typeof(KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>).GetMethod(nameof(KafkaOutputFunctionsForProduceAndConsume<KafkaEventData<string>>.Produce))
                     );
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("TraceId:"));
-                    return foundCount == 1;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider, "TraceId:", 1);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -792,25 +759,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         {
             const int producedMessagesCount = 20;
             var messagePrefix = Guid.NewGuid().ToString() + ":";
+            var testSettings = await CreateTestSettingsAsync();
+            var resolvedTopicName = ResolveTopicName(testSettings, topicName);
 
-            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), triggerFunctionType }))
+            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), triggerFunctionType }, testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), producerFunctionName),
-                    topicName,
+                    resolvedTopicName,
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefix + x)
                     );
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefix));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider, messagePrefix, producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1000);
+                await host.StopAsync();
             }
         }
 
@@ -844,26 +810,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         {
             const int producedMessagesCount = 20;
             var messagePrefix = Guid.NewGuid().ToString() + ":";
+            var testLoggerProvider = CreateTestLoggerProvider();
+            var testSettings = await CreateTestSettingsAsync();
+            var resolvedTopicName = ResolveTopicName(testSettings, topicName);
 
-            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), triggerFunctionType }))
+            using (var host = await StartHostAsync(new[] { typeof(KafkaOutputFunctions), triggerFunctionType }, testLoggerProvider, testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringWithKeyAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), producerFunctionName),
-                    topicName,
+                    resolvedTopicName,
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefix + x),
                     Enumerable.Range(1, producedMessagesCount).Select(x => x.ToString())
                     );
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefix));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(testLoggerProvider, messagePrefix, producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1000);
+                await host.StopAsync();
             }
         }
 
@@ -943,9 +909,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         {
             var outputMethod = (outputFunction.Body as MethodCallExpression).Method;
             var eventList = events.ToList();
+            var testSettings = await CreateTestSettingsAsync();
+            var topicName = ResolveTopicName(testSettings, Constants.StringTopicWithTenPartitionsName);
             foreach (var kafkaEvent in eventList)
             {
-                kafkaEvent.Topic = Constants.StringTopicWithTenPartitionsName;
+                kafkaEvent.Topic = topicName;
             }
             var eventCount = eventList.Count;
             var output = new ConcurrentBag<KafkaEventData<string>>();
@@ -954,7 +922,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 {
                     s.AddSingleton(eventList);
                     s.AddSingleton(output);
-                }
+                },
+                testSettings: testSettings
              ))
             {
                 var jobHost = host.GetJobHost();
@@ -962,17 +931,78 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await TestHelpers.Await(() =>
                 {
-                    var foundCount = output.Count;
-                    return foundCount == eventCount;
+                    var outputValues = output.Select(kafkaEvent => kafkaEvent.Value).ToHashSet();
+                    return eventList.All(kafkaEvent => outputValues.Contains(kafkaEvent.Value));
                 });
-                return output.ToList();
+
+                return output
+                    .Where(kafkaEvent => eventList.Any(inputEvent => inputEvent.Value == kafkaEvent.Value))
+                    .ToList();
             }
         }
 
-        private Task<IHost> StartHostAsync(Type testType, ILoggerProvider customLoggerProvider = null) => StartHostAsync(new[] { testType }, customLoggerProvider);
-
-        private async Task<IHost> StartHostAsync(Type[] testTypes, ILoggerProvider customLoggerProvider = null, Action<IServiceCollection> serviceRegistrationCallback = null, Action<KafkaOptions> configureKafka = null)
+        private static IDictionary<string, string> CreateConsumerGroupSettings()
         {
+            var suffix = Guid.NewGuid().ToString("N");
+            return new Dictionary<string, string>
+            {
+                [Constants.ConsumerGroupID] = "e2e_tests_" + suffix,
+                [Constants.AtLeastOnceConsumerGroupID] = "at_least_once_e2e_" + suffix,
+                [Constants.AtLeastOnceMaxRetriesConsumerGroupID] = "at_least_once_maxretries_e2e_" + suffix,
+            };
+        }
+
+        private async Task<IDictionary<string, string>> CreateTestSettingsAsync()
+        {
+            var settings = CreateConsumerGroupSettings();
+            var suffix = Guid.NewGuid().ToString("N");
+            var topicSpecifications = new[]
+            {
+                AddTopicOverride(settings, Constants.StringTopicWithOnePartitionName, 1, suffix),
+                AddTopicOverride(settings, Constants.StringTopicWithTenPartitionsName, 10, suffix),
+                AddTopicOverride(settings, Constants.StringTopicWithLongKeyAndTenPartitionsName, 10, suffix),
+                AddTopicOverride(settings, Constants.MyAvroRecordTopicName, 10, suffix),
+                AddTopicOverride(settings, Constants.MyKeyAvroRecordTopicName, 10, suffix),
+                AddTopicOverride(settings, Constants.MyProtobufTopicName, 10, suffix),
+                AddTopicOverride(settings, Constants.SchemaRegistryTopicName, 1, suffix),
+                AddTopicOverride(settings, Constants.SchemaRegistryNoKeyTopicName, 1, suffix),
+                AddTopicOverride(settings, Constants.AtLeastOnceTopicName, 1, suffix),
+                AddTopicOverride(settings, Constants.AtLeastOnceMaxRetriesTopicName, 1, suffix),
+            };
+
+            await endToEndTestFixture.CreateTopicsAsync(topicSpecifications);
+            return settings;
+        }
+
+        private static TopicSpecification AddTopicOverride(IDictionary<string, string> settings, string topicName, int partitionCount, string suffix)
+        {
+            var testTopicName = topicName + "-" + suffix;
+            settings[topicName] = testTopicName;
+            return new TopicSpecification { Name = testTopicName, NumPartitions = partitionCount, ReplicationFactor = 1 };
+        }
+
+        private static string ResolveTopicName(IDictionary<string, string> settings, string topicName)
+        {
+            return settings.TryGetValue(topicName, out var resolvedTopicName) ? resolvedTopicName : topicName;
+        }
+
+        private Task<IHost> StartHostAsync(Type testType, ILoggerProvider customLoggerProvider = null, IDictionary<string, string> testSettings = null) => StartHostAsync(new[] { testType }, customLoggerProvider, testSettings: testSettings);
+
+        private static Task WaitForPartitionAssignmentAsync(ILoggerProvider loggerProvider)
+        {
+            if (loggerProvider is not TestLoggerProvider testLoggerProvider)
+            {
+                return Task.CompletedTask;
+            }
+
+            return testLoggerProvider.WaitForLogMessageAsync(
+                logMessage => logMessage.FormattedMessage != null && logMessage.FormattedMessage.Contains("Assigned partitions"));
+        }
+
+        private async Task<IHost> StartHostAsync(Type[] testTypes, ILoggerProvider customLoggerProvider = null, Action<IServiceCollection> serviceRegistrationCallback = null, Action<KafkaOptions> configureKafka = null, IDictionary<string, string> testSettings = null)
+        {
+            var consumerGroupSettings = testSettings ?? await CreateTestSettingsAsync();
+            var effectiveLoggerProvider = customLoggerProvider ?? loggerProvider;
             IHost host = new HostBuilder()
                 .ConfigureWebJobs(builder =>
                 {
@@ -982,6 +1012,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     .AddKafka(kafkaoption =>
                     {
                         kafkaoption.SessionTimeoutMs = 10000;
+                        kafkaoption.AutoOffsetReset = Confluent.Kafka.AutoOffsetReset.Earliest;
                         configureKafka?.Invoke(kafkaoption);
                     });
                 })
@@ -990,6 +1021,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     c.AddTestSettings();
                     c.AddJsonFile("appsettings.tests.json", optional: true);
                     c.AddJsonFile("local.appsettings.tests.json", optional: true);
+                    c.AddInMemoryCollection(consumerGroupSettings);
                 })
                 .ConfigureServices(services =>
                 {
@@ -999,11 +1031,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 .ConfigureLogging(logging =>
                 {
                     logging.ClearProviders();
-                    logging.AddProvider(customLoggerProvider ?? loggerProvider);
+                    logging.AddProvider(effectiveLoggerProvider);
                 })
                 .Build();
 
             await host.StartAsync();
+            await WaitForPartitionAssignmentAsync(effectiveLoggerProvider);
             return host;
         }
 
@@ -1015,28 +1048,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messagePrefixBatch1 = messageMasterPrefix + ":1:";
 
             var loggerProvider1 = CreateTestLoggerProvider();
+            var testSettings = await CreateTestSettingsAsync();
 
-            using (var host = await StartHostAsync(new[] { typeof(SingleItem_Single_Partition_Raw_String_Without_Key_Trigger_Retry), typeof(KafkaOutputFunctions) }, loggerProvider1))
+            using (var host = await StartHostAsync(new[] { typeof(SingleItem_Single_Partition_Raw_String_Without_Key_Trigger_Retry), typeof(KafkaOutputFunctions) }, loggerProvider1, testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithOnePartition.Name,
+                    ResolveTopicName(testSettings, endToEndTestFixture.StringTopicWithOnePartition.Name),
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
 
-                await TestHelpers.Await(() =>
-                {
-                    Thread.Sleep(10000);
-                    foreach (LogMessage logMsg in loggerProvider1.GetAllLogMessages()) {
-                        if (logMsg.Exception != null)
-                        {
-                            Console.WriteLine(logMsg.Exception.InnerException.Message);
-                        }
-                    }
-                    var foundCount = loggerProvider1.GetAllLogMessages().Count(p => p.FormattedMessage != null &&  p.FormattedMessage.Contains($"Executed '{nameof(SingleItem_Single_Partition_Raw_String_Without_Key_Trigger_Retry)}.Trigger'"));
-					return foundCount == 6;
-                });
+                // Wait for the retry function to be executed at least 6 times (initial + retries).
+                // Uses event-driven waiting: resolves as soon as the 6th log arrives, no polling.
+                await loggerProvider1.WaitForLogMessagesAsync(
+                    msgs => msgs.Count(p => p.FormattedMessage != null &&
+                        p.FormattedMessage.Contains($"Executed '{nameof(SingleItem_Single_Partition_Raw_String_Without_Key_Trigger_Retry)}.Trigger'")) >= 6);
 
                 await Task.Delay(1500);
             }
@@ -1052,23 +1079,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             const int producedMessagesCount = 1;
             
             var loggerProvider1 = CreateTestLoggerProvider();
+            var testSettings = await CreateTestSettingsAsync();
 
             using (var host = await StartHostAsync(
                        new[] { typeof(SingleItem_With_Schema_Registry), typeof(KafkaOutputFunctions) },
-                       loggerProvider1))
+                       loggerProvider1,
+                       testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions),
                         nameof(KafkaOutputFunctions.Produce_AsyncCollector_PageView_With_String_Key)),
-                    new { topic = Constants.SchemaRegistryTopicName });
+                    new { topic = ResolveTopicName(testSettings, Constants.SchemaRegistryTopicName) });
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider1.GetAllUserLogMessages().Count(p => p.FormattedMessage != null);
-                    return foundCount == producedMessagesCount;
-                });
+                await loggerProvider1.WaitForUserLogMessagesAsync(logMessage => logMessage.FormattedMessage != null, producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -1084,10 +1109,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messageMasterPrefix = Guid.NewGuid().ToString();
             
             var loggerProvider = CreateTestLoggerProvider();
+            var testSettings = await CreateTestSettingsAsync();
 
             using (var host = await StartHostAsync(
                        new[] { typeof(SingleItem_GenericAvroValue_With_GenericAvroKey_Trigger), typeof(KafkaOutputFunctions) },
-                       loggerProvider))
+                       loggerProvider,
+                       testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
@@ -1096,17 +1123,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     GetStaticMethod(typeof(KafkaOutputFunctions), 
                         nameof(KafkaOutputFunctions.Produce_AsyncCollector_GenericRecordKeyValue)),
                     new { 
-                        topic = Constants.MyKeyAvroRecordTopicName,
+                        topic = ResolveTopicName(testSettings, Constants.MyKeyAvroRecordTopicName),
                         ids = Enumerable.Range(1, producedMessagesCount).Select(x => x),
                         content = Enumerable.Range(1, producedMessagesCount).Select(x => $"{messageMasterPrefix}-{x}")
                     });
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider.GetAllUserLogMessages()
-                        .Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messageMasterPrefix));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider, messageMasterPrefix, producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -1122,10 +1144,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messageMasterPrefix = Guid.NewGuid().ToString();
             
             var loggerProvider = CreateTestLoggerProvider();
+            var testSettings = await CreateTestSettingsAsync();
 
             using (var host = await StartHostAsync(
                        new[] { typeof(SingleItem_GenericAvroValue_With_GenericAvroKey_SchemaRegistryURL), typeof(KafkaOutputFunctions) },
-                       loggerProvider))
+                       loggerProvider,
+                       testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
@@ -1134,17 +1158,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     GetStaticMethod(typeof(KafkaOutputFunctions), 
                         nameof(KafkaOutputFunctions.Produce_AsyncCollector_GenericRecordKeyValue_With_SchemaRegistry)),
                     new { 
-                        topic = Constants.MyKeyAvroRecordTopicName,
+                        topic = ResolveTopicName(testSettings, Constants.MyKeyAvroRecordTopicName),
                         ids = Enumerable.Range(1, producedMessagesCount).Select(x => x),
                         content = Enumerable.Range(1, producedMessagesCount).Select(x => $"{messageMasterPrefix}-{x}")
                     });
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider.GetAllUserLogMessages()
-                        .Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messageMasterPrefix));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider, messageMasterPrefix, producedMessagesCount);
 
                 // Give time for the commit to be saved
                 await Task.Delay(1500);
@@ -1160,10 +1179,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messageMasterPrefix = Guid.NewGuid().ToString();
             
             var loggerProvider = CreateTestLoggerProvider();
+            var testSettings = await CreateTestSettingsAsync();
 
             using (var host = await StartHostAsync(
                        new[] { typeof(SingleItem_With_Schema_Registry_No_Key), typeof(KafkaOutputFunctions) },
-                       loggerProvider))
+                       loggerProvider,
+                       testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
@@ -1171,16 +1192,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                     GetStaticMethod(typeof(KafkaOutputFunctions), 
                         nameof(KafkaOutputFunctions.Produce_AsyncCollector_GenericRecord_NoKey_With_SchemaRegistry)),
                     new { 
-                        topic = Constants.SchemaRegistryNoKeyTopicName,
+                        topic = ResolveTopicName(testSettings, Constants.SchemaRegistryNoKeyTopicName),
                         content = Enumerable.Range(1, producedMessagesCount).Select(x => $"{messageMasterPrefix}-{x}")
                     });
 
-                await TestHelpers.Await(() =>
-                {
-                    var foundCount = loggerProvider.GetAllUserLogMessages()
-                        .Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messageMasterPrefix));
-                    return foundCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider, messageMasterPrefix, producedMessagesCount);
 
                 await Task.Delay(1500);
                 await host.StopAsync();
@@ -1199,6 +1215,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messagePrefix = Guid.NewGuid().ToString() + ":";
 
             var loggerProvider1 = CreateTestLoggerProvider();
+            var testSettings = await CreateTestSettingsAsync();
 
             // CommitOnFailure=false enables at-least-once with in-place retry
             using (var host = await StartHostAsync(
@@ -1207,22 +1224,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 configureKafka: options =>
                 {
                     options.CommitOnFailure = false;
-                }))
+                },
+                testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.AtLeastOnceTopic.Name,
+                    ResolveTopicName(testSettings, endToEndTestFixture.AtLeastOnceTopic.Name),
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefix + x));
 
                 // Wait for all messages to be processed successfully (each message needs 2 attempts)
-                await TestHelpers.Await(() =>
-                {
-                    var successCount = loggerProvider1.GetAllUserLogMessages()
-                        .Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("AtLeastOnce SUCCESS for " + messagePrefix));
-                    return successCount == producedMessagesCount;
-                });
+                await WaitForUserLogMessagesAsync(loggerProvider1, "AtLeastOnce SUCCESS for " + messagePrefix, producedMessagesCount);
 
                 await Task.Delay(1500);
                 await host.StopAsync();
@@ -1252,6 +1265,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             var messagePrefix = Guid.NewGuid().ToString() + ":";
 
             var loggerProvider1 = CreateTestLoggerProvider();
+            var testSettings = await CreateTestSettingsAsync();
 
             using (var host = await StartHostAsync(
                 new[] { typeof(SingleItem_AtLeastOnce_AlwaysFail_Trigger), typeof(KafkaOutputFunctions) },
@@ -1260,23 +1274,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 {
                     options.CommitOnFailure = false;
                     options.MaxRetries = maxRetries;
-                }))
+                },
+                testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 // Produce 2 messages
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.AtLeastOnceMaxRetriesTopic.Name,
+                    ResolveTopicName(testSettings, endToEndTestFixture.AtLeastOnceMaxRetriesTopic.Name),
                     Enumerable.Range(1, 2).Select(x => messagePrefix + x));
 
                 // Wait for the force-commit log that indicates maxRetries was exceeded
-                await TestHelpers.Await(() =>
-                {
-                    var forceCommitLogs = loggerProvider1.GetAllLogMessages()
-                        .Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("force-committed"));
-                    return forceCommitLogs >= 1;
-                });
+                await loggerProvider1.WaitForLogMessageAsync(
+                    logMessage => logMessage.FormattedMessage != null && logMessage.FormattedMessage.Contains("force-committed"));
 
                 await Task.Delay(1500);
                 await host.StopAsync();
@@ -1340,7 +1351,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 Assert.Contains("protobuf-e2e-", Encoding.UTF8.GetString(proto.Value.ToByteArray()));
 
                 // Broker-assigned metadata is populated
-                Assert.Equal(Constants.StringTopicWithTenPartitionsName, proto.Topic);
+                Assert.Equal(consumedEvent.Topic, proto.Topic);
                 Assert.True(proto.Partition >= 0, "Partition should be >= 0");
                 Assert.True(proto.Offset >= 0, "Offset should be >= 0");
                 Assert.NotNull(proto.Timestamp);
@@ -1457,17 +1468,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             while (SingleItem_ParameterBindingData_Trigger.Received.TryTake(out _)) { }
 
             var loggerProvider1 = CreateTestLoggerProvider();
+            var testSettings = await CreateTestSettingsAsync();
+            var topicName = ResolveTopicName(testSettings, Constants.StringTopicWithTenPartitionsName);
 
             using (var host = await StartHostAsync(
                 new[] { typeof(SingleItem_ParameterBindingData_Trigger), typeof(KafkaOutputFunctions) },
-                loggerProvider1))
+                loggerProvider1,
+                testSettings: testSettings))
             {
                 var jobHost = host.GetJobHost();
 
                 // Produce messages via the existing KafkaOutputFunctions
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.Produce_AsyncCollector_String_Without_Key)),
-                    endToEndTestFixture.StringTopicWithTenPartitions.Name,
+                    topicName,
                     Enumerable.Range(1, messageCount).Select(x => messagePrefix + x));
 
                 // Wait for the trigger to receive all messages as ParameterBindingData
@@ -1490,7 +1504,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 var proto = KafkaRecordProto.Parser.ParseFrom(bindingData.Content);
 
                 // Broker-assigned metadata is populated
-                Assert.Equal(Constants.StringTopicWithTenPartitionsName, proto.Topic);
+                Assert.Equal(topicName, proto.Topic);
                 Assert.True(proto.Partition >= 0, "Partition should be >= 0");
                 Assert.True(proto.Offset >= 0, "Offset should be >= 0");
                 Assert.NotNull(proto.Timestamp);

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/TestLoggerProvider.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/TestLoggerProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Extensions.Logging;
 
@@ -12,10 +13,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 {
     public class TestLoggerProvider : ILoggerProvider
     {
+        private const int DefaultLogWaitTimeoutMs = 180 * 1000;
         private readonly LoggerFilterOptions _filter;
         private readonly Action<LogMessage> _logAction;
         private readonly Regex userCategoryRegex = new Regex(@"^Function\.\w+\.User$");
         private readonly Dictionary<string, TestLogger> _loggerCache = new Dictionary<string, TestLogger>();
+        private readonly List<LogWaiter> _logWaiters = new List<LogWaiter>();
+        private readonly object _syncLock = new object();
 
         public TestLoggerProvider(Action<LogMessage> logAction = null)
         {
@@ -23,17 +27,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             _logAction = logAction;
         }
 
-        public IList<TestLogger> CreatedLoggers => _loggerCache.Values.ToList();
+        public IList<TestLogger> CreatedLoggers
+        {
+            get
+            {
+                lock (_syncLock)
+                {
+                    return _loggerCache.Values.ToList();
+                }
+            }
+        }
 
         public ILogger CreateLogger(string categoryName)
         {
-            if (!_loggerCache.TryGetValue(categoryName, out TestLogger logger))
+            lock (_syncLock)
             {
-                logger = new TestLogger(categoryName, _logAction);
-                _loggerCache.Add(categoryName, logger);
-            }
+                if (!_loggerCache.TryGetValue(categoryName, out TestLogger logger))
+                {
+                    logger = new TestLogger(categoryName, OnLogMessage);
+                    _loggerCache.Add(categoryName, logger);
+                }
 
-            return logger;
+                return logger;
+            }
         }
 
         public IEnumerable<LogMessage> GetAllLogMessages() => CreatedLoggers.SelectMany(l => l.GetLogMessages()).OrderBy(p => p.Timestamp);
@@ -45,6 +61,54 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
         public string GetLogString() => string.Join(Environment.NewLine, GetAllLogMessages());
 
+        public async Task WaitForLogMessagesAsync(Func<IReadOnlyList<LogMessage>, bool> condition, int timeout = DefaultLogWaitTimeoutMs)
+        {
+            if (condition == null)
+            {
+                throw new ArgumentNullException(nameof(condition));
+            }
+
+            LogWaiter logWaiter;
+            lock (_syncLock)
+            {
+                if (condition(GetAllLogMessages().ToList()))
+                {
+                    return;
+                }
+
+                logWaiter = new LogWaiter(condition);
+                _logWaiters.Add(logWaiter);
+            }
+
+            var timeoutTask = Task.Delay(timeout);
+            var completedTask = await Task.WhenAny(logWaiter.Task, timeoutTask);
+            if (completedTask != logWaiter.Task)
+            {
+                IReadOnlyList<LogMessage> logMessages;
+                lock (_syncLock)
+                {
+                    _logWaiters.Remove(logWaiter);
+                    logMessages = GetAllLogMessages().ToList();
+                }
+
+                throw new ApplicationException(GetTimeoutMessage(timeout, logMessages));
+            }
+
+            await logWaiter.Task;
+        }
+
+        public Task WaitForLogMessageAsync(Func<LogMessage, bool> predicate, int timeout = DefaultLogWaitTimeoutMs)
+        {
+            return WaitForLogMessagesAsync(logMessages => logMessages.Any(predicate), timeout);
+        }
+
+        public Task WaitForUserLogMessagesAsync(Func<LogMessage, bool> predicate, int count, int timeout = DefaultLogWaitTimeoutMs)
+        {
+            return WaitForLogMessagesAsync(logMessages =>
+                logMessages.Count(logMessage => userCategoryRegex.IsMatch(logMessage.Category) && predicate(logMessage)) >= count,
+                timeout);
+        }
+
         public void ClearAllLogMessages()
         {
             foreach (TestLogger logger in CreatedLoggers)
@@ -55,6 +119,72 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
         public void Dispose()
         {
+        }
+
+        private string GetTimeoutMessage(int timeout, IReadOnlyList<LogMessage> logMessages)
+        {
+            var userLogCount = logMessages.Count(logMessage => userCategoryRegex.IsMatch(logMessage.Category));
+            var recentLogs = logMessages
+                .TakeLast(20)
+                .Select(logMessage => logMessage.ToString());
+
+            return $"Condition not reached within {timeout}ms. Total logs: {logMessages.Count}; user logs: {userLogCount}.{Environment.NewLine}" +
+                "Recent logs:" + Environment.NewLine +
+                string.Join(Environment.NewLine, recentLogs);
+        }
+
+        private void OnLogMessage(LogMessage logMessage)
+        {
+            _logAction?.Invoke(logMessage);
+
+            List<LogWaiter> completedLogWaiters = null;
+            lock (_syncLock)
+            {
+                if (_logWaiters.Count == 0)
+                {
+                    return;
+                }
+
+                var logMessages = GetAllLogMessages().ToList();
+                foreach (var logWaiter in _logWaiters.ToArray())
+                {
+                    if (logWaiter.Condition(logMessages))
+                    {
+                        completedLogWaiters ??= new List<LogWaiter>();
+                        completedLogWaiters.Add(logWaiter);
+                        _logWaiters.Remove(logWaiter);
+                    }
+                }
+            }
+
+            if (completedLogWaiters == null)
+            {
+                return;
+            }
+
+            foreach (var logWaiter in completedLogWaiters)
+            {
+                logWaiter.TrySetResult();
+            }
+        }
+
+        private class LogWaiter
+        {
+            private readonly TaskCompletionSource<object> _completionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public LogWaiter(Func<IReadOnlyList<LogMessage>, bool> condition)
+            {
+                Condition = condition;
+            }
+
+            public Func<IReadOnlyList<LogMessage>, bool> Condition { get; }
+
+            public Task Task => _completionSource.Task;
+
+            public void TrySetResult()
+            {
+                _completionSource.TrySetResult(null);
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureEnvironmentTestCollection.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureEnvironmentTestCollection.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
+{
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class AzureEnvironmentTestCollection
+    {
+        public const string Name = "Azure environment tests";
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/AzureFunctionsFileHelperTest.cs
@@ -19,6 +19,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 {
+    [Collection(AzureEnvironmentTestCollection.Name)]
     public class AzureFunctionsFileHelperTest : IDisposable
     {
         public void Dispose()
@@ -138,6 +139,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             Assert.False(result);
             Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGetValidHttpsCaLocation_WhenAzureRelativeDirectoryHasSubdirectories_ShouldPreserveThem()
+        {
+            var home = Path.Combine(Path.GetTempPath(), nameof(AzureFunctionsFileHelperTest), Guid.NewGuid().ToString("N"));
+            var expected = Directory.CreateDirectory(
+                Path.Combine(
+                    home,
+                    AzureFunctionsFileHelper.AzureDefaultFunctionPathPart1,
+                    AzureFunctionsFileHelper.AzureDefaultFunctionPathPart2,
+                    "certs",
+                    "ca")).FullName;
+
+            try
+            {
+                AzureEnvironment.SetRunningInAzureEnvVars();
+                AzureEnvironment.SetEnvironmentVariable(AzureFunctionsFileHelper.AzureHomeEnvVarName, home);
+
+                var result = AzureFunctionsFileHelper.TryGetValidHttpsCaLocation(
+                    Path.Combine("certs", "ca") + Path.DirectorySeparatorChar,
+                    out var actual);
+
+                Assert.True(result);
+                Assert.Equal(expected, actual);
+            }
+            finally
+            {
+                Directory.Delete(home, recursive: true);
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
@@ -474,6 +474,116 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         [Fact]
+        public async Task When_Both_OAuthBearer_HttpsCaSettings_Are_Set_Should_Throw()
+        {
+            var listenerConfig = new KafkaListenerConfiguration
+            {
+                BrokerList = "testBroker",
+                Topic = "topic",
+                ConsumerGroup = "group1",
+                SaslMechanism = SaslMechanism.OAuthBearer,
+                HttpsCaLocation = "path/to/https-ca.pem",
+                HttpsCaPem = "httpsCaPem",
+            };
+            var target = new KafkaListenerForTest<Null, string>(
+                new Mock<ITriggeredFunctionExecutor>().Object,
+                true,
+                new KafkaOptions(),
+                listenerConfig,
+                requiresKey: true,
+                valueDeserializer: null,
+                keyDeserializer: null,
+                NullLogger.Instance,
+                functionId: "testId",
+                drainModeManager: null);
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => target.StartAsync(default));
+
+            Assert.Contains("https.ca.location", exception.Message);
+            Assert.Contains("https.ca.pem", exception.Message);
+        }
+
+        [Fact]
+        public async Task When_OAuthBearer_HttpsCaLocation_Does_Not_Exist_Should_Throw()
+        {
+            var listenerConfig = new KafkaListenerConfiguration
+            {
+                BrokerList = "testBroker",
+                Topic = "topic",
+                ConsumerGroup = "group1",
+                SaslMechanism = SaslMechanism.OAuthBearer,
+                HttpsCaLocation = "relative/does-not-exist.pem",
+            };
+            var target = new KafkaListenerForTest<Null, string>(
+                new Mock<ITriggeredFunctionExecutor>().Object,
+                true,
+                new KafkaOptions(),
+                listenerConfig,
+                requiresKey: true,
+                valueDeserializer: null,
+                keyDeserializer: null,
+                NullLogger.Instance,
+                functionId: "testId",
+                drainModeManager: null);
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => target.StartAsync(default));
+
+            Assert.Contains("https.ca.location", exception.Message);
+            Assert.Contains("relative/does-not-exist.pem", exception.Message);
+        }
+
+        [Fact]
+        public async Task When_OAuthBearer_HttpsCaSettings_Are_Set_Should_Be_Set_In_Consumer_Config()
+        {
+            var executor = new Mock<ITriggeredFunctionExecutor>();
+            var consumer = new Mock<IConsumer<Null, string>>();
+
+            var listenerConfig = new KafkaListenerConfiguration()
+            {
+                BrokerList = "testBroker",
+                Topic = "topic",
+                ConsumerGroup = "group1",
+                SaslMechanism = SaslMechanism.OAuthBearer,
+                SaslOAuthBearerMethod = SaslOauthbearerMethod.Oidc,
+                SaslOAuthBearerClientId = "clientId",
+                SaslOAuthBearerClientSecret = "secret",
+                SaslOAuthBearerScope = "scope",
+                SaslOAuthBearerTokenEndpointUrl = "endpointUrl",
+                SaslOAuthBearerExtensions = "key=value",
+                HttpsCaLocation = "probe",
+                SecurityProtocol = SecurityProtocol.SaslSsl,
+            };
+
+            var target = new KafkaListenerForTest<Null, string>(
+                executor.Object,
+                true,
+                new KafkaOptions(),
+                listenerConfig,
+                requiresKey: true,
+                valueDeserializer: null,
+                keyDeserializer: null,
+                NullLogger.Instance,
+                functionId: "testId",
+                drainModeManager: null);
+
+            target.SetConsumer(consumer.Object);
+
+            await target.StartAsync(default);
+
+            Assert.Equal("probe", target.ConsumerConfig.Get("https.ca.location"));
+            Assert.Null(target.ConsumerConfig.Get("https.ca.pem"));
+            Assert.Equal(SaslMechanism.OAuthBearer, target.ConsumerConfig.SaslMechanism);
+            Assert.Equal(SaslOauthbearerMethod.Oidc, target.ConsumerConfig.SaslOauthbearerMethod);
+            Assert.Equal("clientId", target.ConsumerConfig.SaslOauthbearerClientId);
+            Assert.Equal("secret", target.ConsumerConfig.SaslOauthbearerClientSecret);
+            Assert.Equal("scope", target.ConsumerConfig.SaslOauthbearerScope);
+            Assert.Equal("endpointUrl", target.ConsumerConfig.SaslOauthbearerTokenEndpointUrl);
+            Assert.Equal("key=value", target.ConsumerConfig.SaslOauthbearerExtensions);
+
+            await target.StopAsync(default);
+        }
+
+        [Fact]
         public async Task When_Using_Single_Dispatcher_Slow_Partition_Processing_Should_Not_Delay_Other_Partitions()
         {
             const int Offset1 = 1;

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaMetricsProviderForTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaMetricsProviderForTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         readonly List<TopicPartition> allPartitions;
         readonly List<TopicPartition> onlyAssignedPartitions;
 
-        public KafkaMetricsProviderForTest(string topicName, AdminClientConfig adminClientConfig, IConsumer<TKey, TValue> consumer, ILogger logger, List<TopicPartition> topicPartitions, List<TopicPartition> assignedPartitions) : base(topicName, adminClientConfig, consumer, logger)
+        public KafkaMetricsProviderForTest(string topicName, AdminClientConfig adminClientConfig, IConsumer<TKey, TValue> consumer, ILogger logger, List<TopicPartition> topicPartitions, List<TopicPartition> assignedPartitions, bool ownsConsumer = true) : base(topicName, adminClientConfig, consumer, logger, ownsConsumer)
         {
             this.allPartitions = topicPartitions;
             this.onlyAssignedPartitions = assignedPartitions;

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaMetricsProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaMetricsProviderTest.cs
@@ -139,5 +139,62 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal(topicPartitions.Count, metrics.PartitionCount);
             Assert.Equal(0, metrics.TotalLag);
         }
+
+        [Fact]
+        public void KafkaMetricsProvider_Implements_IDisposable()
+        {
+            // Assert type implements IDisposable
+            Assert.True(metricsProvider is IDisposable, "KafkaMetricsProvider should implement IDisposable");
+        }
+
+        [Fact]
+        public void KafkaMetricsProvider_Dispose_Closes_And_Disposes_Consumer()
+        {
+            // Arrange
+            consumer.Setup(x => x.Close()).Verifiable();
+            consumer.Setup(x => x.Dispose()).Verifiable();
+
+            // Act
+            metricsProvider.Dispose();
+
+            // Assert
+            consumer.Verify(x => x.Close(), Times.Once);
+            consumer.Verify(x => x.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public void KafkaMetricsProvider_Dispose_Can_Be_Called_Multiple_Times()
+        {
+            // Arrange
+            consumer.Setup(x => x.Close());
+            consumer.Setup(x => x.Dispose());
+
+            // Act - calling Dispose multiple times should not throw
+            metricsProvider.Dispose();
+            metricsProvider.Dispose();
+            metricsProvider.Dispose();
+
+            // Assert - Close and Dispose should only be called once
+            consumer.Verify(x => x.Close(), Times.Once);
+            consumer.Verify(x => x.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public void KafkaMetricsProvider_Dispose_Does_Not_Close_Or_Dispose_NonOwned_Consumer()
+        {
+            var nonOwningMetricsProvider = new KafkaMetricsProviderForTest<string, byte[]>(
+                TopicName,
+                new AdminClientConfig(),
+                consumer.Object,
+                NullLogger.Instance,
+                topicPartitions,
+                assignedPartitions,
+                ownsConsumer: false);
+
+            nonOwningMetricsProvider.Dispose();
+
+            consumer.Verify(x => x.Close(), Times.Never);
+            consumer.Verify(x => x.Dispose(), Times.Never);
+        }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaProducerFactoryTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaProducerFactoryTest.cs
@@ -17,18 +17,23 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 {
+    [Collection(AzureEnvironmentTestCollection.Name)]
     public class KafkaProducerFactoryTest : IDisposable
     {
         private List<FileInfo> createdFiles = new List<FileInfo>();
         private readonly IConfigurationRoot emptyConfiguration;
+        private readonly DirectoryInfo testDirectory;
 
         public KafkaProducerFactoryTest()
         {
             this.emptyConfiguration = new ConfigurationBuilder().Build();
+            this.testDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), nameof(KafkaProducerFactoryTest), Guid.NewGuid().ToString("N")));
         }
 
         public void Dispose()
         {
+            AzureEnvironment.ClearEnvironmentVariables();
+
             foreach (var fi in this.createdFiles)
             {
                 if (fi.Exists)
@@ -38,12 +43,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             }
 
             this.createdFiles.Clear();
+
+            if (this.testDirectory.Exists)
+            {
+                this.testDirectory.Delete(recursive: true);
+            }
         }
 
         private FileInfo CreateFile(string fileName)
         {
-            File.WriteAllText(fileName, "dummy contents");
-            var file = new FileInfo(fileName);
+            var filePath = Path.IsPathRooted(fileName) ? fileName : Path.Combine(this.testDirectory.FullName, fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+            File.WriteAllText(filePath, "dummy contents");
+            var file = new FileInfo(filePath);
             this.createdFiles.Add(file);
 
             return file;
@@ -307,7 +319,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         {
             AzureEnvironment.SetRunningInAzureEnvVars();
 
-            var currentFolder = Directory.GetCurrentDirectory();
+            var currentFolder = this.testDirectory.FullName;
             var folder1 = Directory.CreateDirectory(Path.Combine(currentFolder, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart1));
             Directory.CreateDirectory(Path.Combine(folder1.FullName, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart2));
 
@@ -342,7 +354,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         {
             AzureEnvironment.SetRunningInAzureEnvVars();
 
-            var currentFolder = Directory.GetCurrentDirectory();
+            var currentFolder = this.testDirectory.FullName;
             var folder1 = Directory.CreateDirectory(Path.Combine(currentFolder, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart1));
             Directory.CreateDirectory(Path.Combine(folder1.FullName, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart2));
 
@@ -382,6 +394,73 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         [Fact]
+        public void GetProducerConfig_When_Both_HttpsCaSettings_Are_Defined_Should_Throw()
+        {
+            var attribute = new KafkaAttribute("brokers:9092", "myTopic")
+            {
+                AuthenticationMode = BrokerAuthenticationMode.OAuthBearer,
+                HttpsCaLocation = "httpsCaLocation",
+                HttpsCaPem = "httpsCaPem",
+            };
+
+            var entity = new KafkaProducerEntity
+            {
+                Attribute = attribute,
+                ValueType = typeof(ProtoUser),
+            };
+
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
+
+            var exception = Assert.Throws<ArgumentException>(() => factory.GetProducerConfig(entity));
+
+            Assert.Contains("https.ca.location", exception.Message);
+            Assert.Contains("https.ca.pem", exception.Message);
+        }
+
+        [Fact]
+        public void GetProducerConfig_When_HttpsCaLocation_Does_Not_Exist_Should_Throw()
+        {
+            var attribute = new KafkaAttribute("brokers:9092", "myTopic")
+            {
+                AuthenticationMode = BrokerAuthenticationMode.OAuthBearer,
+                HttpsCaLocation = "relative/does-not-exist.pem",
+            };
+            var entity = new KafkaProducerEntity
+            {
+                Attribute = attribute,
+                ValueType = typeof(ProtoUser),
+            };
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
+
+            var exception = Assert.Throws<ArgumentException>(() => factory.GetProducerConfig(entity));
+
+            Assert.Contains("https.ca.location", exception.Message);
+            Assert.Contains("relative/does-not-exist.pem", exception.Message);
+        }
+
+        [Fact]
+        public void GetProducerConfig_When_AuthenticationMode_Is_Not_OAuthBearer_Should_Ignore_HttpsCaSettings()
+        {
+            var attribute = new KafkaAttribute("brokers:9092", "myTopic")
+            {
+                AuthenticationMode = BrokerAuthenticationMode.Plain,
+                HttpsCaLocation = "relative/does-not-exist.pem",
+                HttpsCaPem = "httpsCaPem",
+            };
+            var entity = new KafkaProducerEntity
+            {
+                Attribute = attribute,
+                ValueType = typeof(ProtoUser),
+            };
+            var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
+
+            var config = factory.GetProducerConfig(entity);
+
+            Assert.Null(config.Get("https.ca.location"));
+            Assert.Null(config.Get("https.ca.pem"));
+        }
+
+        [Fact]
         public void GetProducerConfig_When_OAuthBearer_Auth_Defined_Should_Contain_Them()
         {
             var attribute = new KafkaAttribute("brokers:9092", "myTopic")
@@ -394,6 +473,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 OAuthBearerScope = "scope",
                 OAuthBearerExtensions = "key=value",
                 OAuthBearerTokenEndpointUrl = "endpointUrl",
+                HttpsCaLocation = "probe",
             };
 
             var entity = new KafkaProducerEntity()
@@ -404,7 +484,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             var factory = new KafkaProducerFactory(emptyConfiguration, new DefaultNameResolver(emptyConfiguration), NullLoggerFactory.Instance);
             var config = factory.GetProducerConfig(entity);
-            Assert.Equal(16, config.Count());
+            Assert.Equal(17, config.Count());
             Assert.Equal("brokers:9092", config.BootstrapServers);
             Assert.Equal(SecurityProtocol.SaslSsl, config.SecurityProtocol);
             Assert.Equal(SaslMechanism.OAuthBearer, config.SaslMechanism);
@@ -414,6 +494,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("scope", config.SaslOauthbearerScope);
             Assert.Equal("key=value", config.SaslOauthbearerExtensions);
             Assert.Equal("endpointUrl", config.SaslOauthbearerTokenEndpointUrl);
+            Assert.Equal("probe", config.Get("https.ca.location"));
+            Assert.Null(config.Get("https.ca.pem"));
         }
 
         [Fact]
@@ -431,6 +513,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 OAuthBearerScope = "OAuthBearerScope",
                 OAuthBearerExtensions = "OAuthBearerExtensions",
                 OAuthBearerTokenEndpointUrl = "OAuthBearerTokenEndpointUrl",
+                HttpsCaPem = "HttpsCaPem",
             };
 
             var entity = new KafkaProducerEntity
@@ -446,6 +529,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 {"OAuthBearerScope", "scope"},
                 {"OAuthBearerExtensions", "key=value"},
                 {"OAuthBearerTokenEndpointUrl", "endpointUrl"},
+                {"HttpsCaPem", "line1\\nline2"},
             };
 
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(configSslLocations).Build();
@@ -461,6 +545,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("scope", config.SaslOauthbearerScope);
             Assert.Equal("key=value", config.SaslOauthbearerExtensions);
             Assert.Equal("endpointUrl", config.SaslOauthbearerTokenEndpointUrl);
+            Assert.Null(config.Get("https.ca.location"));
+            Assert.Equal("line1\nline2", config.Get("https.ca.pem"));
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaScalerProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaScalerProviderTest.cs
@@ -13,6 +13,9 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
+using System.Reflection;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 {
@@ -50,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 { "Password", "password" },
             };
             var triggerMetadata = new TriggerMetadata(metadata);
-            var kafkaScalerProvider = new KafkaScalerProvider(serviceProvider.Object, triggerMetadata);
+            using var kafkaScalerProvider = new KafkaScalerProvider(serviceProvider.Object, triggerMetadata);
             Assert.NotNull(kafkaScalerProvider);
             Assert.NotNull(kafkaScalerProvider.GetTargetScaler());
             Assert.NotNull(kafkaScalerProvider.GetMonitor());
@@ -70,10 +73,179 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 { "SslCertificateandKeyPEM", "dummycertificateandkeypem" }
             };
             var triggerMetadata = new TriggerMetadata(metadata);
-            var kafkaScalerProvider = new KafkaScalerProvider(serviceProvider.Object, triggerMetadata);
+            using var kafkaScalerProvider = new KafkaScalerProvider(serviceProvider.Object, triggerMetadata);
             Assert.NotNull(kafkaScalerProvider);
             Assert.NotNull(kafkaScalerProvider.GetTargetScaler());
             Assert.NotNull(kafkaScalerProvider.GetMonitor());
+        }
+
+        [Fact]
+        public void GetConsumerConfiguration_When_Both_HttpsCaSettings_Are_Defined_Should_Throw()
+        {
+            var metadata = new KafkaScalerProvider.KafkaMetaData
+            {
+                BrokerList = "brokerList",
+                ConsumerGroup = "consumerGroup",
+                AuthenticationMode = BrokerAuthenticationMode.OAuthBearer,
+                HttpsCaLocation = "httpsCaLocation",
+                HttpsCaPem = "httpsCaPem",
+            };
+
+            var exception = Assert.Throws<ArgumentException>(
+                () => KafkaScalerProvider.GetConsumerConfiguration(metadata, config.Object, nameResolver.Object));
+
+            Assert.Contains("https.ca.location", exception.Message);
+            Assert.Contains("https.ca.pem", exception.Message);
+        }
+
+        [Fact]
+        public void GetConsumerConfiguration_When_HttpsCaLocation_Does_Not_Exist_Should_Throw()
+        {
+            var metadata = new KafkaScalerProvider.KafkaMetaData
+            {
+                BrokerList = "brokerList",
+                ConsumerGroup = "consumerGroup",
+                AuthenticationMode = BrokerAuthenticationMode.OAuthBearer,
+                HttpsCaLocation = "relative/does-not-exist.pem",
+            };
+
+            var exception = Assert.Throws<ArgumentException>(
+                () => KafkaScalerProvider.GetConsumerConfiguration(metadata, config.Object, nameResolver.Object));
+
+            Assert.Contains("https.ca.location", exception.Message);
+            Assert.Contains("relative/does-not-exist.pem", exception.Message);
+        }
+
+        [Fact]
+        public void GetConsumerConfiguration_When_OAuthBearer_HttpsCaSettings_Resolve_From_AppSetting()
+        {
+            var metadata = new KafkaScalerProvider.KafkaMetaData
+            {
+                BrokerList = "brokerList",
+                ConsumerGroup = "consumerGroup",
+                AuthenticationMode = BrokerAuthenticationMode.OAuthBearer,
+                Protocol = BrokerProtocol.SaslSsl,
+                OAuthBearerClientId = "OAuthBearerClientId",
+                OAuthBearerClientSecret = "OAuthBearerClientSecret",
+                OAuthBearerMethod = SaslOauthbearerMethod.Oidc,
+                OAuthBearerScope = "OAuthBearerScope",
+                OAuthBearerExtensions = "OAuthBearerExtensions",
+                OAuthBearerTokenEndpointUrl = "OAuthBearerTokenEndpointUrl",
+                HttpsCaLocation = "HttpsCaLocation",
+            };
+
+            var settings = new Dictionary<string, string>
+            {
+                {"brokerList", "broker:9092"},
+                {"consumerGroup", "group"},
+                {"OAuthBearerClientId", "clientId"},
+                {"OAuthBearerClientSecret", "secret"},
+                {"OAuthBearerScope", "scope"},
+                {"OAuthBearerExtensions", "key=value"},
+                {"OAuthBearerTokenEndpointUrl", "endpointUrl"},
+                {"HttpsCaLocation", "probe"},
+            };
+
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+            var result = KafkaScalerProvider.GetConsumerConfiguration(metadata, configuration, new DefaultNameResolver(configuration));
+
+            Assert.Equal("broker:9092", result.BootstrapServers);
+            Assert.Equal("group", result.GroupId);
+            Assert.Equal(SecurityProtocol.SaslSsl, result.SecurityProtocol);
+            Assert.Equal(SaslMechanism.OAuthBearer, result.SaslMechanism);
+            Assert.Equal("secret", result.SaslOauthbearerClientSecret);
+            Assert.Equal("clientId", result.SaslOauthbearerClientId);
+            Assert.Equal(SaslOauthbearerMethod.Oidc, result.SaslOauthbearerMethod);
+            Assert.Equal("scope", result.SaslOauthbearerScope);
+            Assert.Equal("key=value", result.SaslOauthbearerExtensions);
+            Assert.Equal("endpointUrl", result.SaslOauthbearerTokenEndpointUrl);
+            Assert.Equal("probe", result.Get("https.ca.location"));
+            Assert.Null(result.Get("https.ca.pem"));
+        }
+
+        [Fact]
+        public void KafkaScalerProvider_Implements_IDisposable()
+        {
+            // Arrange
+            var metadata = new JObject
+            {
+                { "BrokerList", "brokerList" },
+                { "Topic", "topicTest" },
+                { "ConsumerGroup", "consumerGroup" },
+                { "LagThreshold", 1000 },
+            };
+            var triggerMetadata = new TriggerMetadata(metadata);
+
+            // Act & Assert
+            using var kafkaScalerProvider = new KafkaScalerProvider(serviceProvider.Object, triggerMetadata);
+            Assert.True(kafkaScalerProvider is IDisposable, "KafkaScalerProvider should implement IDisposable");
+
+            // Dispose should not throw
+            kafkaScalerProvider.Dispose();
+
+            // Multiple Dispose calls should be safe
+            kafkaScalerProvider.Dispose();
+        }
+
+        [Fact]
+        public void KafkaScalerProvider_DisposesConsumer_WhenConstructionFails()
+        {
+            var consumer = new Mock<IConsumer<string, string>>();
+            var triggerMetadata = CreateTriggerMetadata(string.Empty);
+
+            Assert.Throws<ArgumentException>(() =>
+                new KafkaScalerProvider(serviceProvider.Object, triggerMetadata, _ => consumer.Object));
+
+            consumer.Verify(x => x.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public void AddKafkaScaleForTrigger_RegistersDistinctProvidersForEachTrigger_AndDisposesThem()
+        {
+            var services = new TestServiceCollection();
+            services.AddSingleton(config.Object);
+            services.AddSingleton(nameResolver.Object);
+            services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+            services.AddSingleton(Options.Create(new KafkaOptions()));
+
+            var builder = new Mock<IWebJobsBuilder>();
+            builder.SetupGet(p => p.Services).Returns(services);
+
+            builder.Object.AddKafkaScaleForTrigger(CreateTriggerMetadata("topic-one"));
+            builder.Object.AddKafkaScaleForTrigger(CreateTriggerMetadata("topic-two"));
+
+            var provider = services.BuildServiceProvider();
+            var monitorProviders = provider.GetServices<IScaleMonitorProvider>().ToArray();
+            var targetScalerProviders = provider.GetServices<ITargetScalerProvider>().ToArray();
+
+            Assert.Equal(2, monitorProviders.Length);
+            Assert.Equal(2, targetScalerProviders.Length);
+            Assert.NotSame(monitorProviders[0], monitorProviders[1]);
+            Assert.Same(monitorProviders[0], targetScalerProviders[0]);
+            Assert.Same(monitorProviders[1], targetScalerProviders[1]);
+
+            provider.Dispose();
+
+            var disposedField = typeof(KafkaScalerProvider).GetField("_disposed", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.All(monitorProviders, scalerProvider =>
+                Assert.True((bool)disposedField.GetValue(scalerProvider)));
+        }
+
+        private static TriggerMetadata CreateTriggerMetadata(string topic)
+        {
+            var metadata = new JObject
+            {
+                { "BrokerList", "brokerList" },
+                { "Topic", topic },
+                { "ConsumerGroup", "consumerGroup" },
+                { "LagThreshold", 1000 },
+            };
+
+            return new TriggerMetadata(metadata);
+        }
+
+        private sealed class TestServiceCollection : List<ServiceDescriptor>, IServiceCollection
+        {
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerAttributeBindingProviderTest.cs
@@ -24,9 +24,11 @@ using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 {
+    [Collection(AzureEnvironmentTestCollection.Name)]
     public class KafkaTriggerAttributeBindingProviderTest : IDisposable
     {
         private List<FileInfo> createdFiles = new List<FileInfo>();
+        private readonly DirectoryInfo testDirectory;
         private IConfigurationRoot emptyConfiguration;
         private IDrainModeManager drainModeManager = new Mock<IDrainModeManager>().Object;
 
@@ -34,10 +36,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         {
             this.emptyConfiguration = new ConfigurationBuilder()
                 .Build();
+            this.testDirectory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), nameof(KafkaTriggerAttributeBindingProviderTest), Guid.NewGuid().ToString("N")));
         }
 
         public void Dispose()
         {
+            AzureEnvironment.ClearEnvironmentVariables();
+
             foreach (var fi in this.createdFiles)
             {
                 if (fi.Exists)
@@ -47,12 +52,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             }
 
             this.createdFiles.Clear();
+
+            if (this.testDirectory.Exists)
+            {
+                this.testDirectory.Delete(recursive: true);
+            }
         }
 
         private FileInfo CreateFile(string fileName)
         {
-            File.WriteAllText(fileName, "dummy contents");
-            var file = new FileInfo(fileName);
+            var filePath = Path.IsPathRooted(fileName) ? fileName : Path.Combine(this.testDirectory.FullName, fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+            File.WriteAllText(filePath, "dummy contents");
+            var file = new FileInfo(filePath);
             this.createdFiles.Add(file);
 
             return file;
@@ -407,7 +419,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         {
             AzureEnvironment.SetRunningInAzureEnvVars();
 
-            var currentFolder = Directory.GetCurrentDirectory();
+            var currentFolder = this.testDirectory.FullName;
             var folder1 = Directory.CreateDirectory(Path.Combine(currentFolder, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart1));
             Directory.CreateDirectory(Path.Combine(folder1.FullName, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart2));
 
@@ -451,7 +463,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         {
             AzureEnvironment.SetRunningInAzureEnvVars();
 
-            var currentFolder = Directory.GetCurrentDirectory();
+            var currentFolder = this.testDirectory.FullName;
             var folder1 = Directory.CreateDirectory(Path.Combine(currentFolder, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart1));
             Directory.CreateDirectory(Path.Combine(folder1.FullName, AzureFunctionsFileHelper.AzureDefaultFunctionPathPart2));
 
@@ -568,8 +580,83 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
         }
 
         [Fact]
+        public void GetConsumerConfig_When_Both_HttpsCaSettings_Are_Defined_Should_Throw()
+        {
+            var httpsCa = this.CreateFile("httpsCa.pem");
+            var attribute = new KafkaTriggerAttribute("brokers:9092", "myTopic")
+            {
+                AuthenticationMode = BrokerAuthenticationMode.OAuthBearer,
+                HttpsCaLocation = httpsCa.FullName,
+                HttpsCaPem = "httpsCaPem",
+            };
+
+            var bindingProvider = new KafkaTriggerAttributeBindingProvider(
+                this.emptyConfiguration,
+                Options.Create(new KafkaOptions()),
+                new KafkaEventDataConvertManager(NullLogger.Instance),
+                new DefaultNameResolver(this.emptyConfiguration),
+                NullLoggerFactory.Instance,
+                drainModeManager);
+            var consumerConfigMethod = typeof(KafkaTriggerAttributeBindingProvider).GetMethod("CreateConsumerConfiguration", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var exception = Assert.Throws<TargetInvocationException>(() => consumerConfigMethod.Invoke(bindingProvider, new object[] { attribute }));
+            var argumentException = Assert.IsType<ArgumentException>(exception.InnerException);
+
+            Assert.Contains("https.ca.location", argumentException.Message);
+            Assert.Contains("https.ca.pem", argumentException.Message);
+        }
+
+        [Fact]
+        public void GetConsumerConfig_When_HttpsCaLocation_Is_Directory_Should_Accept_It()
+        {
+            var attribute = new KafkaTriggerAttribute("brokers:9092", "myTopic")
+            {
+                AuthenticationMode = BrokerAuthenticationMode.OAuthBearer,
+                HttpsCaLocation = this.testDirectory.FullName,
+            };
+
+            var bindingProvider = new KafkaTriggerAttributeBindingProvider(
+                this.emptyConfiguration,
+                Options.Create(new KafkaOptions()),
+                new KafkaEventDataConvertManager(NullLogger.Instance),
+                new DefaultNameResolver(this.emptyConfiguration),
+                NullLoggerFactory.Instance,
+                drainModeManager);
+            var consumerConfigMethod = typeof(KafkaTriggerAttributeBindingProvider).GetMethod("CreateConsumerConfiguration", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var result = (KafkaListenerConfiguration)consumerConfigMethod.Invoke(bindingProvider, new object[] { attribute });
+
+            Assert.Equal(this.testDirectory.FullName, result.HttpsCaLocation);
+        }
+
+        [Fact]
+        public void GetConsumerConfig_When_HttpsCaLocation_Is_Probe_Should_Accept_It()
+        {
+            var attribute = new KafkaTriggerAttribute("brokers:9092", "myTopic")
+            {
+                AuthenticationMode = BrokerAuthenticationMode.OAuthBearer,
+                HttpsCaLocation = "probe",
+            };
+
+            var bindingProvider = new KafkaTriggerAttributeBindingProvider(
+                this.emptyConfiguration,
+                Options.Create(new KafkaOptions()),
+                new KafkaEventDataConvertManager(NullLogger.Instance),
+                new DefaultNameResolver(this.emptyConfiguration),
+                NullLoggerFactory.Instance,
+                drainModeManager);
+            var consumerConfigMethod = typeof(KafkaTriggerAttributeBindingProvider).GetMethod("CreateConsumerConfiguration", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var result = (KafkaListenerConfiguration)consumerConfigMethod.Invoke(bindingProvider, new object[] { attribute });
+
+            Assert.Equal("probe", result.HttpsCaLocation);
+        }
+
+        [Fact]
         public void GetConsumerConfig_When_OAuthBearer_Auth_Defined_Should_Contain_Them()
         {
+            var httpsCa = this.CreateFile("httpsCa.pem");
+
             var attribute = new KafkaTriggerAttribute("brokers:9092", "myTopic")
             {
                 AuthenticationMode = BrokerAuthenticationMode.OAuthBearer,
@@ -580,6 +667,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 OAuthBearerScope = "scope",
                 OAuthBearerExtensions = "key=value",
                 OAuthBearerTokenEndpointUrl = "endpointUrl",
+                HttpsCaLocation = httpsCa.FullName,
             };
 
             var config = this.emptyConfiguration;
@@ -604,6 +692,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("scope", result.SaslOAuthBearerScope);
             Assert.Equal("key=value", result.SaslOAuthBearerExtensions);
             Assert.Equal("endpointUrl", result.SaslOAuthBearerTokenEndpointUrl);
+            Assert.Equal(httpsCa.FullName, result.HttpsCaLocation);
+            Assert.Null(result.HttpsCaPem);
         }
 
         [Fact]
@@ -621,6 +711,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 OAuthBearerScope = "OAuthBearerScope",
                 OAuthBearerExtensions = "OAuthBearerExtensions",
                 OAuthBearerTokenEndpointUrl = "OAuthBearerTokenEndpointUrl",
+                HttpsCaPem = "HttpsCaPem",
             };
 
             var configSslLocations = new Dictionary<string, string>
@@ -630,6 +721,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 {"OAuthBearerScope", "scope"},
                 {"OAuthBearerExtensions", "key=value"},
                 {"OAuthBearerTokenEndpointUrl", "endpointUrl"},
+                {"HttpsCaPem", "httpsCaPem"},
             };
 
             var config = new ConfigurationBuilder().AddInMemoryCollection(configSslLocations).Build();
@@ -655,6 +747,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             Assert.Equal("scope", result.SaslOAuthBearerScope);
             Assert.Equal("key=value", result.SaslOAuthBearerExtensions);
             Assert.Equal("endpointUrl", result.SaslOAuthBearerTokenEndpointUrl);
+            Assert.Null(result.HttpsCaLocation);
+            Assert.Equal("httpsCaPem", result.HttpsCaPem);
         }
     }
 }


### PR DESCRIPTION
## Release 4.3.3

This PR syncs the `dev` branch content to `master` for release **4.3.3**.

### What this PR does
- Replaces the master tree with dev content
- Removes dev-only files
- Updates `build/common.props` to `4.3.3`

### Changes since last release
- feat: add Kafka OAuth HTTPS CA settings (#649) (#650)
- Fix thread leak by implementing IDisposable in KafkaScalerProvider (#607)
- Fix Azure environment test isolation (#666)
- ci: route SBOM npm access through CFS (#665)
- ci: add npm CFS redirect and fix Sonatype Maven mirror (#663)
- ci: route Maven dependencies through CFS upstream-public feed (#661)
- Upgrade Confluent Kafka dependencies to 2.11.1 (#656)
- fix: restrict librdkafka native library override (#654)
- Migrate Docker Hub images to ACR cache (#652)
- Create CODEOWNERS file for automatic PR reviewers (#651)
- Upgrade Confluent Kafka dependencies (#644)
- Add es-metadata.yml (schema 1.0.0) (#643)
