### PR TITLE
Remove redundant SBOM generation task

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -165,13 +165,3 @@ extends:
                   folderPath: $(Build.ArtifactStagingDirectory)
                   pattern: Microsoft.Azure.WebJobs.Extensions.Kafka.*.nupkg
                   signType: nuget
-
-              - task: ManifestGeneratorTask@0
-                displayName: SBOM Generation Task
-                inputs:
-                  BuildDropPath: $(Build.ArtifactStagingDirectory)
-                  PackageName: Microsoft.Azure.WebJobs.Extensions.Kafka
-                  Verbosity: Information
-                env:
-                  NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
-                  NPM_CONFIG_REPLACE_REGISTRY_HOST: always


### PR DESCRIPTION
## Summary

- remove the explicit `ManifestGeneratorTask@0` invocation from the official build
- rely on SBOM generation provided by the 1ES `pipelineArtifact` output
- avoid the npm registry connections observed during the explicit SBOM scan under Network Isolation

## Evidence

Official build 298670 reported 50 `CFSClean` violations for `registry.npmjs.org` from `/usr/local/bin/node`. The explicit SBOM task ran immediately before Network Isolation stopped and scanned `/mnt/vss/_work/1`.

Public build 299211 uses the same repository without the explicit task and reports `CFSClean`, `CFSClean2`, `CFSClean3`, and Default Deny as compliant.