### PR TITLE
Backport removal of redundant SBOM generation task to master

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -165,13 +165,3 @@ extends:
                   folderPath: $(Build.ArtifactStagingDirectory)
                   pattern: Microsoft.Azure.WebJobs.Extensions.Kafka.*.nupkg
                   signType: nuget
-
-              - task: ManifestGeneratorTask@0
-                displayName: SBOM Generation Task
-                inputs:
-                  BuildDropPath: $(Build.ArtifactStagingDirectory)
-                  PackageName: Microsoft.Azure.WebJobs.Extensions.Kafka
-                  Verbosity: Information
-                env:
-                  NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
-                  NPM_CONFIG_REPLACE_REGISTRY_HOST: always


### PR DESCRIPTION
## Summary

- backport #674 to `master`
- remove the explicit `ManifestGeneratorTask@0` invocation from the official build
- rely on SBOM generation provided by the 1ES `pipelineArtifact` output

## Source

Cherry-picked commit `9ef2866` from #674.