### PR TITLE
ci: route Maven plugin npm access through CFS

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -134,6 +134,8 @@ extends:
                   cd ../EventHub
                   mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
                 displayName: "Package Java Functions for Codeql"
+                env:
+                  NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
               - task: DotNetCoreCLI@2
                 displayName: Run unit tests


### PR DESCRIPTION
## Summary

- route the Java Maven plugin's hidden `npm view azure-functions-core-tools dist-tags.core` request through the authenticated CFS npm feed
- explicitly select the repository `.npmrc` for npm subprocesses launched from nested Java project directories
- preserve the existing `npmAuthenticate@0` ordering before Maven packaging

## Root cause

`azure-functions-maven-plugin:1.36.0` invokes npm while packaging both Java end-to-end test projects. Because those commands run beneath the nested project directories, npm did not select the authenticated root `.npmrc` and contacted `registry.npmjs.org` during official build 299597.

## Validation

- parsed `eng/ci/official-build.yml` successfully
- verified `npmAuthenticate@0` remains before `Package Java Functions for Codeql`
- verified `NPM_CONFIG_USERCONFIG` resolves to `$(Build.SourcesDirectory)/.npmrc`
- ran `git diff --check`