### PR TITLE
ci: route Maven plugin npm access through CFS

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -134,6 +134,8 @@ extends:
                   cd ../EventHub
                   mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
                 displayName: "Package Java Functions for Codeql"
+                env:
+                  NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
               - task: DotNetCoreCLI@2
                 displayName: Run unit tests


### PR DESCRIPTION
Cherry-picks #676 onto master to route Maven plugin npm access through CFS.\n\nCherry-picked commit: 53f20da395c2431d549570dfd412ef681628f68d